### PR TITLE
Implement initialize route

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,12 @@ uvicorn server.main:app --reload
 
 Then access `http://localhost:8000/query/{tool_name}` with optional query
 parameters to call a specific tool.
+
+To check the available tools programmatically, first call the `/initialize`
+endpoint:
+
+```bash
+curl -X POST http://localhost:8000/initialize
+```
+
+This returns a JSON object listing the supported tool names.

--- a/server/main.py
+++ b/server/main.py
@@ -1,4 +1,5 @@
 from fastapi import FastAPI, HTTPException
+from fastapi.responses import JSONResponse
 
 from .tools.twse import TWSETool
 
@@ -9,6 +10,18 @@ TOOLS = {
     "all_stocks": TWSETool("/v1/tradingInfo/allStocks"),
     "daily_summary": TWSETool("/v1/exchangeReport/STOCK_DAY_AVG_ALL"),
 }
+
+
+@app.get("/")
+async def root():
+    """Basic health check endpoint."""
+    return {"status": "ok"}
+
+
+@app.post("/initialize")
+async def initialize():
+    """Return basic server capabilities."""
+    return JSONResponse({"tools": list(TOOLS.keys())})
 
 @app.get("/query/{tool_name}")
 async def query(tool_name: str, params: dict | None = None):


### PR DESCRIPTION
## Summary
- support `/initialize` to expose available tools
- add a basic health check on `/`
- document new endpoint in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847143b357c832382f1f41e8fb7128e