### PR TITLE
refactor: Phase 3 — table-drive list tools via create_list_tool factory

### DIFF
--- a/tools/broker.py
+++ b/tools/broker.py
@@ -1,235 +1,84 @@
 """Broker tools for TWSE data."""
 
-from typing import Dict, Optional
+from typing import Optional
 from fastmcp import FastMCP
-from utils import (
-    TWSEAPIClient,
-    MSG_NO_DATA,
-    handle_api_errors,
-    format_list_response,
-    create_simple_list_formatter,
-)
+from utils import TWSEAPIClient, create_list_tool, create_simple_list_formatter
+
+
+def _doc(summary: str, name_hint: Optional[str] = None) -> str:
+    """Build a broker tool docstring, optionally with a ``name`` argument line."""
+    lines = [summary, "", "        Args:"]
+    if name_hint is not None:
+        lines.append(f"            name: {name_hint}")
+    lines.append("            limit: 回傳筆數上限（預設 50）")
+    lines.append("            offset: 跳過前 N 筆（預設 0，搭配 limit 分頁）")
+    return "\n".join(lines)
+
+
+# (endpoint, name, summary, label, empty_data_type, filter_field, name_hint, formatter)
+BROKER_TOOLS = [
+    (
+        "/opendata/t187ap01", "get_broker_service_personnel",
+        "查詢券商業務別人員數。", "券商業務別人員數資料", "券商業務別人員數",
+        None, None,
+        lambda i: f"- {i.get('職位', 'N/A')}: 總人數 {i.get('合計', 'N/A')} (受託買賣 {i.get('受託買賣', 'N/A')}, 自行買賣 {i.get('自行買賣', 'N/A')})\n",
+    ),
+    (
+        "/opendata/t187ap20", "get_broker_monthly_statements",
+        "查詢各券商每月月計表。", "券商每月月計表資料", "券商每月月計表",
+        "券商名稱", '券商名稱關鍵字（選填），例如 "遠智" 只回傳名稱含該字串的券商',
+        lambda i: f"- {i.get('券商名稱', 'N/A')} ({i.get('券商代號', 'N/A')}) [{i.get('出表日期', 'N/A')}] {i.get('會計科目名稱', 'N/A')}: {i.get('借方餘額', 'N/A')}\n",
+    ),
+    (
+        "/opendata/t187ap21", "get_broker_income_expenditure",
+        "查詢各券商收支概況表資料。", "券商收支概況表資料", "券商收支概況表",
+        "券商名稱", "券商名稱關鍵字（選填）",
+        lambda i: f"- {i.get('券商名稱', 'N/A')} ({i.get('券商代號', 'N/A')}) [{i.get('出表日期', 'N/A')}] {i.get('會計科目名稱', 'N/A')}: {i.get('本月金額', 'N/A')}\n",
+    ),
+    (
+        "/opendata/t187ap18", "get_broker_basic_info",
+        "查詢證券商基本資料。", "證券商基本資料", "證券商基本",
+        "券商(證券IB)簡稱", '券商簡稱關鍵字（選填），例如 "元大"',
+        create_simple_list_formatter("券商(證券IB)簡稱", "證券代號", "設立日期"),
+    ),
+    (
+        "/opendata/t187ap19", "get_broker_electronic_trading_statistics",
+        "查詢電子式交易統計資訊。", "電子式交易統計資訊", "電子式交易統計",
+        None, None,
+        lambda i: f"- [{i.get('出表日期', 'N/A')}] 月份 {i.get('成交月份', 'N/A')}: 總成交筆數 {i.get('公司總成交筆數', 'N/A')}, 電子式成交筆數 {i.get('成交筆數', 'N/A')}\n",
+    ),
+    (
+        "/opendata/OpenData_BRK01", "get_broker_gender_statistics",
+        "查詢證券商營業員男女人數統計資料。", "證券商營業員男女人數統計資料", "證券商營業員男女人數統計",
+        None, None,
+        lambda i: f"- 券商代號 {i.get('證券商代號', 'N/A')}: 男 {i.get('男性員工人數', 'N/A')} 人, 女 {i.get('女性員工人數', 'N/A')} 人, 總計 {i.get('總人數', 'N/A')} 人\n",
+    ),
+    (
+        "/opendata/OpenData_BRK02", "get_broker_branch_info",
+        "查詢證券商分公司基本資料。", "證券商分公司基本資料", "證券商分公司基本",
+        "證券商名稱", '券商名稱關鍵字（選填），例如 "富邦"',
+        lambda i: f"- {i.get('證券商名稱', 'N/A')} ({i.get('證券商代號', 'N/A')}): {i.get('地址', 'N/A')}, 電話 {i.get('電話', 'N/A')}\n",
+    ),
+    (
+        "/brokerService/secRegData", "get_brokers_offering_regular_investment",
+        "查詢開辦定期定額業務證券商名單。", "開辦定期定額業務證券商", "開辦定期定額業務證券商名單",
+        "Name", "券商名稱關鍵字（選填）",
+        lambda i: f"- {i.get('Name', 'N/A')} ({i.get('SecuritiesFirmCode', 'N/A')}): 經紀業務 {i.get('BrokerageBusinessStartingDate', 'N/A')}, 財富管理 {i.get('WealthManagementBusinessStartingDate', 'N/A')}\n",
+    ),
+    (
+        "/brokerService/brokerList", "get_broker_headquarters_info",
+        "查詢證券商總公司基本資料。", "證券商總公司基本資料", "證券商總公司基本",
+        "Name", "券商名稱關鍵字（選填）",
+        lambda i: f"- {i.get('Name', 'N/A')} ({i.get('Code', 'N/A')}): 設立 {i.get('EstablishmentDate', 'N/A')}, 地址 {i.get('Address', 'N/A')}, 電話 {i.get('Telephone', 'N/A')}\n",
+    ),
+]
+
 
 def register_tools(mcp: FastMCP, client: Optional[TWSEAPIClient] = None) -> None:
     """Register broker tools with the MCP instance."""
 
-    _client = client or TWSEAPIClient.get_instance()
-
-    @mcp.tool
-    @handle_api_errors()
-    def get_broker_service_personnel(limit: int = 50, offset: int = 0) -> str:
-        """查詢券商業務別人員數。
-
-        Args:
-            limit: 回傳筆數上限（預設 50）
-            offset: 跳過前 N 筆（預設 0，搭配 limit 分頁）
-        """
-        data = _client.fetch_data("/opendata/t187ap01")
-        if not data:
-            return MSG_NO_DATA.format(data_type="券商業務別人員數")
-
-        def formatter(item):
-            position = item.get("職位", "N/A")
-            total = item.get("合計", "N/A")
-            trading = item.get("受託買賣", "N/A")
-            self_trading = item.get("自行買賣", "N/A")
-            return f"- {position}: 總人數 {total} (受託買賣 {trading}, 自行買賣 {self_trading})\n"
-
-        return format_list_response(data, "券商業務別人員數資料", formatter, limit=limit, offset=offset)
-
-    @mcp.tool
-    @handle_api_errors()
-    def get_broker_monthly_statements(name: str = "", limit: int = 50, offset: int = 0) -> str:
-        """查詢各券商每月月計表。
-
-        Args:
-            name: 券商名稱關鍵字（選填），例如 "遠智" 只回傳名稱含該字串的券商
-            limit: 回傳筆數上限（預設 50）
-            offset: 跳過前 N 筆（預設 0，搭配 limit 分頁）
-        """
-        data = _client.fetch_data("/opendata/t187ap20")
-        if not data:
-            return MSG_NO_DATA.format(data_type="券商每月月計表")
-
-        if name:
-            data = [d for d in data if name in d.get("券商名稱", "")]
-
-        def formatter(item: Dict[str, str]) -> str:
-            broker_name = item.get("券商名稱", "N/A")
-            code = item.get("券商代號", "N/A")
-            date = item.get("出表日期", "N/A")
-            subject = item.get("會計科目名稱", "N/A")
-            debit = item.get("借方餘額", "N/A")
-            return f"- {broker_name} ({code}) [{date}] {subject}: {debit}\n"
-
-        return format_list_response(data, "券商每月月計表資料", formatter, limit=limit, offset=offset)
-
-    @mcp.tool
-    @handle_api_errors()
-    def get_broker_income_expenditure(name: str = "", limit: int = 50, offset: int = 0) -> str:
-        """查詢各券商收支概況表資料。
-
-        Args:
-            name: 券商名稱關鍵字（選填）
-            limit: 回傳筆數上限（預設 50）
-            offset: 跳過前 N 筆（預設 0，搭配 limit 分頁）
-        """
-        data = _client.fetch_data("/opendata/t187ap21")
-        if not data:
-            return MSG_NO_DATA.format(data_type="券商收支概況表")
-
-        if name:
-            data = [d for d in data if name in d.get("券商名稱", "")]
-
-        def formatter(item: Dict[str, str]) -> str:
-            broker_name = item.get("券商名稱", "N/A")
-            code = item.get("券商代號", "N/A")
-            date = item.get("出表日期", "N/A")
-            subject = item.get("會計科目名稱", "N/A")
-            amount = item.get("本月金額", "N/A")
-            return f"- {broker_name} ({code}) [{date}] {subject}: {amount}\n"
-
-        return format_list_response(data, "券商收支概況表資料", formatter, limit=limit, offset=offset)
-
-    @mcp.tool
-    @handle_api_errors()
-    def get_broker_basic_info(name: str = "", limit: int = 50, offset: int = 0) -> str:
-        """查詢證券商基本資料。
-
-        Args:
-            name: 券商簡稱關鍵字（選填），例如 "元大"
-            limit: 回傳筆數上限（預設 50）
-            offset: 跳過前 N 筆（預設 0，搭配 limit 分頁）
-        """
-        data = _client.fetch_data("/opendata/t187ap18")
-        if not data:
-            return MSG_NO_DATA.format(data_type="證券商基本")
-
-        if name:
-            data = [d for d in data if name in d.get("券商(證券IB)簡稱", "")]
-
-        formatter = create_simple_list_formatter("券商(證券IB)簡稱", "證券代號", "設立日期")
-        return format_list_response(data, "證券商基本資料", formatter, limit=limit, offset=offset)
-
-    @mcp.tool
-    @handle_api_errors()
-    def get_broker_electronic_trading_statistics(limit: int = 50, offset: int = 0) -> str:
-        """查詢電子式交易統計資訊。
-
-        Args:
-            limit: 回傳筆數上限（預設 50）
-            offset: 跳過前 N 筆（預設 0，搭配 limit 分頁）
-        """
-        data = _client.fetch_data("/opendata/t187ap19")
-        if not data:
-            return MSG_NO_DATA.format(data_type="電子式交易統計")
-
-        def formatter(item: Dict[str, str]) -> str:
-            date = item.get("出表日期", "N/A")
-            month = item.get("成交月份", "N/A")
-            total_trades = item.get("公司總成交筆數", "N/A")
-            electronic_trades = item.get("成交筆數", "N/A")
-            return f"- [{date}] 月份 {month}: 總成交筆數 {total_trades}, 電子式成交筆數 {electronic_trades}\n"
-
-        return format_list_response(data, "電子式交易統計資訊", formatter, limit=limit, offset=offset)
-
-    @mcp.tool
-    @handle_api_errors()
-    def get_broker_gender_statistics(limit: int = 50, offset: int = 0) -> str:
-        """查詢證券商營業員男女人數統計資料。
-
-        Args:
-            limit: 回傳筆數上限（預設 50）
-            offset: 跳過前 N 筆（預設 0，搭配 limit 分頁）
-        """
-        data = _client.fetch_data("/opendata/OpenData_BRK01")
-        if not data:
-            return MSG_NO_DATA.format(data_type="證券商營業員男女人數統計")
-
-        def formatter(item: Dict[str, str]) -> str:
-            broker_code = item.get("證券商代號", "N/A")
-            male_count = item.get("男性員工人數", "N/A")
-            female_count = item.get("女性員工人數", "N/A")
-            total = item.get("總人數", "N/A")
-            return f"- 券商代號 {broker_code}: 男 {male_count} 人, 女 {female_count} 人, 總計 {total} 人\n"
-
-        return format_list_response(data, "證券商營業員男女人數統計資料", formatter, limit=limit, offset=offset)
-
-    @mcp.tool
-    @handle_api_errors()
-    def get_broker_branch_info(name: str = "", limit: int = 50, offset: int = 0) -> str:
-        """查詢證券商分公司基本資料。
-
-        Args:
-            name: 券商名稱關鍵字（選填），例如 "富邦"
-            limit: 回傳筆數上限（預設 50）
-            offset: 跳過前 N 筆（預設 0，搭配 limit 分頁）
-        """
-        data = _client.fetch_data("/opendata/OpenData_BRK02")
-        if not data:
-            return MSG_NO_DATA.format(data_type="證券商分公司基本")
-
-        if name:
-            data = [d for d in data if name in d.get("證券商名稱", "")]
-
-        def formatter(item: Dict[str, str]) -> str:
-            code = item.get("證券商代號", "N/A")
-            broker_name = item.get("證券商名稱", "N/A")
-            address = item.get("地址", "N/A")
-            phone = item.get("電話", "N/A")
-            return f"- {broker_name} ({code}): {address}, 電話 {phone}\n"
-
-        return format_list_response(data, "證券商分公司基本資料", formatter, limit=limit, offset=offset)
-
-    @mcp.tool
-    @handle_api_errors()
-    def get_brokers_offering_regular_investment(name: str = "", limit: int = 50, offset: int = 0) -> str:
-        """查詢開辦定期定額業務證券商名單。
-
-        Args:
-            name: 券商名稱關鍵字（選填）
-            limit: 回傳筆數上限（預設 50）
-            offset: 跳過前 N 筆（預設 0，搭配 limit 分頁）
-        """
-        data = _client.fetch_data("/brokerService/secRegData")
-        if not data:
-            return MSG_NO_DATA.format(data_type="開辦定期定額業務證券商名單")
-
-        if name:
-            data = [d for d in data if name in d.get("Name", "")]
-
-        def formatter(item: Dict[str, str]) -> str:
-            code = item.get("SecuritiesFirmCode", "N/A")
-            broker_name = item.get("Name", "N/A")
-            start_date = item.get("BrokerageBusinessStartingDate", "N/A")
-            wealth_date = item.get("WealthManagementBusinessStartingDate", "N/A")
-            return f"- {broker_name} ({code}): 經紀業務 {start_date}, 財富管理 {wealth_date}\n"
-
-        return format_list_response(data, "開辦定期定額業務證券商", formatter, limit=limit, offset=offset)
-
-    @mcp.tool
-    @handle_api_errors()
-    def get_broker_headquarters_info(name: str = "", limit: int = 50, offset: int = 0) -> str:
-        """查詢證券商總公司基本資料。
-
-        Args:
-            name: 券商名稱關鍵字（選填）
-            limit: 回傳筆數上限（預設 50）
-            offset: 跳過前 N 筆（預設 0，搭配 limit 分頁）
-        """
-        data = _client.fetch_data("/brokerService/brokerList")
-        if not data:
-            return MSG_NO_DATA.format(data_type="證券商總公司基本")
-
-        if name:
-            data = [d for d in data if name in d.get("Name", "")]
-
-        def formatter(item: Dict[str, str]) -> str:
-            code = item.get("Code", "N/A")
-            broker_name = item.get("Name", "N/A")
-            establishment_date = item.get("EstablishmentDate", "N/A")
-            address = item.get("Address", "N/A")
-            phone = item.get("Telephone", "N/A")
-            return f"- {broker_name} ({code}): 設立 {establishment_date}, 地址 {address}, 電話 {phone}\n"
-
-        return format_list_response(data, "證券商總公司基本資料", formatter, limit=limit, offset=offset)
+    for endpoint, name, summary, label, empty_type, filter_field, name_hint, formatter in BROKER_TOOLS:
+        create_list_tool(
+            mcp, endpoint, name, _doc(summary, name_hint), label, empty_type,
+            formatter, filter_field=filter_field, client=client,
+        )

--- a/tools/company/basic_info.py
+++ b/tools/company/basic_info.py
@@ -10,7 +10,97 @@ from utils import (
     MSG_NO_DATA,
     format_list_response,
     create_company_tool,
+    create_list_tool,
 )
+
+
+def _truncate(text: str, n: int = 100) -> str:
+    """Return text, appending '...' when longer than n chars (legacy rendering)."""
+    return f"{text[:n]}..." if len(text) > n else text
+
+
+def _fmt_ownership_change(i):
+    result = f"- {i.get('公司名稱', 'N/A')} ({i.get('公司代號', 'N/A')}): {i.get('經營權異動日期', 'N/A')}\n"
+    desc = i.get("經營權異動說明", "")
+    if desc:
+        result += f"  說明: {_truncate(desc)}\n"
+    return result
+
+
+def _fmt_cumulative_voting(i):
+    result = f"- {i.get('公司名稱', 'N/A')} ({i.get('公司代號', 'N/A')}): {i.get('董監事選任方式', 'N/A')}"
+    meeting_date = i.get("股東常(臨時)會日期-日期", "")
+    if meeting_date:
+        result += f" (股東會日期: {meeting_date})"
+    return result + "\n"
+
+
+def _fmt_proposal_exercise(i):
+    result = f"- {i.get('公司名稱', 'N/A')} ({i.get('公司代號', 'N/A')}): 股東會 {i.get('召開股東會日期', 'N/A')}\n"
+    period = i.get("股東依公司法第172條之1行使提案權-提案受理期間", "")
+    if period:
+        result += f"  提案受理期間: {period}\n"
+    content = i.get("提案內容", "")
+    if content:
+        result += f"  提案內容: {_truncate(content)}\n"
+    return result
+
+
+def _list_doc(summary: str, name_label: str, has_name: bool = True) -> str:
+    lines = [summary, "", "        Args:"]
+    if has_name:
+        lines.append(f"            name: {name_label}（選填）")
+    lines.append("            limit: 回傳筆數上限（預設 50）")
+    lines.append("            offset: 跳過前 N 筆（預設 0，搭配 limit 分頁）")
+    return "\n".join(lines)
+
+
+# Simple list tools: fetch → optional name filter → paginate.
+# (endpoint, name, summary, label, empty_data_type, filter_field, name_label, formatter)
+SIMPLE_LIST_TOOLS = [
+    (
+        "/announcement/punish", "get_market_disposal_stocks",
+        "查詢集中市場公布處置股票。", "集中市場公布處置股票", "集中市場公布處置股票",
+        "Name", "股票名稱關鍵字",
+        lambda i: f"- {i.get('Name', 'N/A')} ({i.get('Code', 'N/A')}): {i.get('DispositionMeasures', 'N/A')} - {i.get('ReasonsOfDisposition', 'N/A')}\n",
+    ),
+    (
+        "/opendata/t187ap24_L", "get_companies_with_ownership_changes",
+        "查詢上市公司經營權及營業範圍異(變)動專區-經營權異動公司。", "上市公司經營權異動資料", "上市公司經營權異動",
+        "公司名稱", "公司名稱關鍵字", _fmt_ownership_change,
+    ),
+    (
+        "/opendata/t187ap26_L", "get_companies_ownership_changes_business_scope",
+        "查詢上市公司經營權及營業範圍異(變)動專區-經營權異動且營業範圍重大變更停止買賣公司。",
+        "經營權異動且營業範圍重大變更停止買賣公司資料", "經營權異動且營業範圍重大變更停止買賣公司",
+        None, None,
+        lambda i: f"- {i.get('公司名稱', 'N/A')} ({i.get('公司代號', 'N/A')}): {i.get('停止買賣日期', 'N/A')}\n",
+    ),
+    (
+        "/opendata/t187ap27_L", "get_companies_ownership_changes_business_scope_trading",
+        "查詢上市公司經營權及營業範圍異(變)動專區-經營權異動且營業範圍重大變更列為變更交易公司。",
+        "經營權異動且營業範圍重大變更列為變更交易公司資料", "經營權異動且營業範圍重大變更列為變更交易公司",
+        None, None,
+        lambda i: f"- {i.get('公司名稱', 'N/A')} ({i.get('公司代號', 'N/A')}): {i.get('變更日期', 'N/A')}\n",
+    ),
+    (
+        "/opendata/t187ap33_L", "get_company_ceo_dual_role",
+        "查詢上市公司董事長是否兼任總經理。", "上市公司董事長兼任總經理資料", "上市公司董事長兼任總經理",
+        "公司名稱", "公司名稱關鍵字",
+        lambda i: f"- {i.get('公司名稱', 'N/A')} ({i.get('公司代號', 'N/A')}): {i.get('董事長是否兼任總經理', 'N/A')}\n",
+    ),
+    (
+        "/opendata/t187ap34_L", "get_companies_cumulative_voting",
+        "查詢上市公司採累積投票制、全額連記法、候選人提名制選任董監事及當選資料彙總表。",
+        "上市公司採累積投票制選任董監事資料", "上市公司採累積投票制選任董監事",
+        "公司名稱", "公司名稱關鍵字", _fmt_cumulative_voting,
+    ),
+    (
+        "/opendata/t187ap35_L", "get_company_shareholder_proposal_exercise",
+        "查詢上市公司股東行使提案權情形彙總表。", "上市公司股東行使提案權資料", "上市公司股東行使提案權",
+        "公司名稱", "公司名稱關鍵字", _fmt_proposal_exercise,
+    ),
+]
 
 # Simple tools: (endpoint, function_name, mcp_description)
 # All follow the same pattern: fetch_company_data(endpoint, code) → format as properties.
@@ -59,6 +149,13 @@ def register_tools(mcp: FastMCP, client: Optional[TWSEAPIClient] = None) -> None
 
     for endpoint, name, doc in SIMPLE_BASIC_INFO_TOOLS:
         create_company_tool(mcp, endpoint, name, doc, client)
+
+    for endpoint, name, summary, label, empty_type, filter_field, name_label, formatter in SIMPLE_LIST_TOOLS:
+        create_list_tool(
+            mcp, endpoint, name,
+            _list_doc(summary, name_label, has_name=filter_field is not None),
+            label, empty_type, formatter, filter_field=filter_field, client=client,
+        )
 
     # --- Complex tools with custom logic ---
 
@@ -164,31 +261,6 @@ def register_tools(mcp: FastMCP, client: Optional[TWSEAPIClient] = None) -> None
 
     @mcp.tool
     @handle_api_errors()
-    def get_market_disposal_stocks(name: str = "", limit: int = 50, offset: int = 0) -> str:
-        """查詢集中市場公布處置股票。
-
-        Args:
-            name: 股票名稱關鍵字（選填）
-            limit: 回傳筆數上限（預設 50）
-            offset: 跳過前 N 筆（預設 0，搭配 limit 分頁）
-        """
-        data = _client.fetch_data("/announcement/punish")
-        if not data:
-            return MSG_NO_DATA.format(data_type="集中市場公布處置股票")
-
-        if name:
-            data = [d for d in data if name in d.get("Name", "")]
-
-        def formatter(item):
-            return (
-                f"- {item.get('Name', 'N/A')} ({item.get('Code', 'N/A')}): "
-                f"{item.get('DispositionMeasures', 'N/A')} - {item.get('ReasonsOfDisposition', 'N/A')}\n"
-            )
-
-        return format_list_response(data, "集中市場公布處置股票", formatter, limit=limit, offset=offset)
-
-    @mcp.tool
-    @handle_api_errors()
     def get_company_board_insufficient_shares_consecutive() -> str:
         """查詢上市公司董事、監察人持股不足法定成數連續達3個月以上彙總表。"""
         data = _client.fetch_data("/opendata/t187ap10_L")
@@ -266,35 +338,6 @@ def register_tools(mcp: FastMCP, client: Optional[TWSEAPIClient] = None) -> None
 
     @mcp.tool
     @handle_api_errors()
-    def get_companies_with_ownership_changes(name: str = "", limit: int = 50, offset: int = 0) -> str:
-        """查詢上市公司經營權及營業範圍異(變)動專區-經營權異動公司。
-
-        Args:
-            name: 公司名稱關鍵字（選填）
-            limit: 回傳筆數上限（預設 50）
-            offset: 跳過前 N 筆（預設 0，搭配 limit 分頁）
-        """
-        data = _client.fetch_data("/opendata/t187ap24_L")
-        if not data:
-            return MSG_NO_DATA.format(data_type="上市公司經營權異動")
-
-        if name:
-            data = [d for d in data if name in d.get("公司名稱", "")]
-
-        def formatter(item):
-            company_code = item.get("公司代號", "N/A")
-            company_name = item.get("公司名稱", "N/A")
-            change_date = item.get("經營權異動日期", "N/A")
-            change_desc = item.get("經營權異動說明", "")
-            result = f"- {company_name} ({company_code}): {change_date}\n"
-            if change_desc:
-                result += f"  說明: {change_desc[:100]}...\n" if len(change_desc) > 100 else f"  說明: {change_desc}\n"
-            return result
-
-        return format_list_response(data, "上市公司經營權異動資料", formatter, limit=limit, offset=offset)
-
-    @mcp.tool
-    @handle_api_errors()
     def get_company_shareholder_meeting_dates(name: str = "", limit: int = 50, offset: int = 0) -> str:
         """查詢上市公司召開股東常(臨時)會日期、地點及採用電子投票情形等資料彙總表。
 
@@ -366,67 +409,6 @@ def register_tools(mcp: FastMCP, client: Optional[TWSEAPIClient] = None) -> None
 
     @mcp.tool
     @handle_api_errors()
-    def get_companies_ownership_changes_business_scope(limit: int = 50, offset: int = 0) -> str:
-        """查詢上市公司經營權及營業範圍異(變)動專區-經營權異動且營業範圍重大變更停止買賣公司。
-
-        Args:
-            limit: 回傳筆數上限（預設 50）
-            offset: 跳過前 N 筆（預設 0，搭配 limit 分頁）
-        """
-        data = _client.fetch_data("/opendata/t187ap26_L")
-        if not data:
-            return MSG_NO_DATA.format(data_type="經營權異動且營業範圍重大變更停止買賣公司")
-
-        def formatter(item):
-            return f"- {item.get('公司名稱', 'N/A')} ({item.get('公司代號', 'N/A')}): {item.get('停止買賣日期', 'N/A')}\n"
-
-        return format_list_response(data, "經營權異動且營業範圍重大變更停止買賣公司資料", formatter, limit=limit, offset=offset)
-
-    @mcp.tool
-    @handle_api_errors()
-    def get_companies_ownership_changes_business_scope_trading(limit: int = 50, offset: int = 0) -> str:
-        """查詢上市公司經營權及營業範圍異(變)動專區-經營權異動且營業範圍重大變更列為變更交易公司。
-
-        Args:
-            limit: 回傳筆數上限（預設 50）
-            offset: 跳過前 N 筆（預設 0，搭配 limit 分頁）
-        """
-        data = _client.fetch_data("/opendata/t187ap27_L")
-        if not data:
-            return MSG_NO_DATA.format(data_type="經營權異動且營業範圍重大變更列為變更交易公司")
-
-        def formatter(item):
-            return f"- {item.get('公司名稱', 'N/A')} ({item.get('公司代號', 'N/A')}): {item.get('變更日期', 'N/A')}\n"
-
-        return format_list_response(data, "經營權異動且營業範圍重大變更列為變更交易公司資料", formatter, limit=limit, offset=offset)
-
-    @mcp.tool
-    @handle_api_errors()
-    def get_company_ceo_dual_role(name: str = "", limit: int = 50, offset: int = 0) -> str:
-        """查詢上市公司董事長是否兼任總經理。
-
-        Args:
-            name: 公司名稱關鍵字（選填）
-            limit: 回傳筆數上限（預設 50）
-            offset: 跳過前 N 筆（預設 0，搭配 limit 分頁）
-        """
-        data = _client.fetch_data("/opendata/t187ap33_L")
-        if not data:
-            return MSG_NO_DATA.format(data_type="上市公司董事長兼任總經理")
-
-        if name:
-            data = [d for d in data if name in d.get("公司名稱", "")]
-
-        def formatter(item):
-            return (
-                f"- {item.get('公司名稱', 'N/A')} ({item.get('公司代號', 'N/A')}): "
-                f"{item.get('董事長是否兼任總經理', 'N/A')}\n"
-            )
-
-        return format_list_response(data, "上市公司董事長兼任總經理資料", formatter, limit=limit, offset=offset)
-
-    @mcp.tool
-    @handle_api_errors()
     def get_company_board_pledged_shares() -> str:
         """查詢上市公司董事、監察人質權設定占董事及監察人實際持有股數彙總表。"""
         data = _client.fetch_data("/opendata/t187ap09_L")
@@ -441,63 +423,3 @@ def register_tools(mcp: FastMCP, client: Optional[TWSEAPIClient] = None) -> None
                 result += f"質權比例 {percentage_range}%：\n{companies_text}\n\n"
         return result
 
-    @mcp.tool
-    @handle_api_errors()
-    def get_companies_cumulative_voting(name: str = "", limit: int = 50, offset: int = 0) -> str:
-        """查詢上市公司採累積投票制、全額連記法、候選人提名制選任董監事及當選資料彙總表。
-
-        Args:
-            name: 公司名稱關鍵字（選填）
-            limit: 回傳筆數上限（預設 50）
-            offset: 跳過前 N 筆（預設 0，搭配 limit 分頁）
-        """
-        data = _client.fetch_data("/opendata/t187ap34_L")
-        if not data:
-            return MSG_NO_DATA.format(data_type="上市公司採累積投票制選任董監事")
-
-        if name:
-            data = [d for d in data if name in d.get("公司名稱", "")]
-
-        def formatter(item):
-            company_code = item.get("公司代號", "N/A")
-            company_name = item.get("公司名稱", "N/A")
-            voting_system = item.get("董監事選任方式", "N/A")
-            meeting_date = item.get("股東常(臨時)會日期-日期", "")
-            result = f"- {company_name} ({company_code}): {voting_system}"
-            if meeting_date:
-                result += f" (股東會日期: {meeting_date})"
-            return result + "\n"
-
-        return format_list_response(data, "上市公司採累積投票制選任董監事資料", formatter, limit=limit, offset=offset)
-
-    @mcp.tool
-    @handle_api_errors()
-    def get_company_shareholder_proposal_exercise(name: str = "", limit: int = 50, offset: int = 0) -> str:
-        """查詢上市公司股東行使提案權情形彙總表。
-
-        Args:
-            name: 公司名稱關鍵字（選填）
-            limit: 回傳筆數上限（預設 50）
-            offset: 跳過前 N 筆（預設 0，搭配 limit 分頁）
-        """
-        data = _client.fetch_data("/opendata/t187ap35_L")
-        if not data:
-            return MSG_NO_DATA.format(data_type="上市公司股東行使提案權")
-
-        if name:
-            data = [d for d in data if name in d.get("公司名稱", "")]
-
-        def formatter(item):
-            company_code = item.get("公司代號", "N/A")
-            company_name = item.get("公司名稱", "N/A")
-            meeting_date = item.get("召開股東會日期", "N/A")
-            proposal_period = item.get("股東依公司法第172條之1行使提案權-提案受理期間", "")
-            proposal_content = item.get("提案內容", "")
-            result = f"- {company_name} ({company_code}): 股東會 {meeting_date}\n"
-            if proposal_period:
-                result += f"  提案受理期間: {proposal_period}\n"
-            if proposal_content:
-                result += f"  提案內容: {proposal_content[:100]}...\n" if len(proposal_content) > 100 else f"  提案內容: {proposal_content}\n"
-            return result
-
-        return format_list_response(data, "上市公司股東行使提案權資料", formatter, limit=limit, offset=offset)

--- a/tools/company/listing.py
+++ b/tools/company/listing.py
@@ -2,118 +2,57 @@
 
 from typing import Optional
 from fastmcp import FastMCP
-from utils import (
-    TWSEAPIClient,
-    MSG_NO_DATA,
-    handle_api_errors,
-    format_list_response,
-)
+from utils import TWSEAPIClient, create_list_tool
+
+
+def _doc(summary: str) -> str:
+    return "\n".join([
+        summary, "",
+        "        Args:",
+        "            name: 公司名稱關鍵字（選填）",
+        "            limit: 回傳筆數上限（預設 50）",
+        "            offset: 跳過前 N 筆（預設 0，搭配 limit 分頁）",
+    ])
+
+
+def _apply_listing_formatter(i):
+    return (
+        f"- {i.get('Company', 'N/A')} ({i.get('Code', 'N/A')}): "
+        f"申請日期 {i.get('ApplicationDate', 'N/A')}, 核准日期 {i.get('ApprovedDate', 'N/A')}, "
+        f"上市日期 {i.get('ListingDate', 'N/A')}\n"
+    )
+
+
+# (endpoint, name, summary, label, empty_data_type, formatter)
+LISTING_TOOLS = [
+    (
+        "/company/applylistingForeign", "get_foreign_companies_applying_for_listing",
+        "查詢外國公司向證交所申請第一上市之公司。", "外國公司申請第一上市資料",
+        "外國公司申請第一上市", _apply_listing_formatter,
+    ),
+    (
+        "/company/newlisting", "get_recently_listed_companies",
+        "查詢最近上市公司。", "最近上市公司資料", "最近上市公司",
+        lambda i: f"- {i.get('Company', 'N/A')} ({i.get('Code', 'N/A')}): 上市日期 {i.get('ListingDate', 'N/A')}\n",
+    ),
+    (
+        "/company/suspendListingCsvAndHtml", "get_suspended_listed_companies",
+        "查詢終止上市公司。", "終止上市公司資料", "終止上市公司",
+        lambda i: f"- {i.get('Company', 'N/A')} ({i.get('Code', 'N/A')}): 終止日期 {i.get('DelistingDate', 'N/A')}\n",
+    ),
+    (
+        "/company/applylistingLocal", "get_local_companies_applying_for_listing",
+        "查詢申請上市之本國公司。", "申請上市之本國公司資料",
+        "申請上市之本國公司", _apply_listing_formatter,
+    ),
+]
+
 
 def register_tools(mcp: FastMCP, client: Optional[TWSEAPIClient] = None) -> None:
     """Register company listing tools with the MCP instance."""
 
-    _client = client or TWSEAPIClient.get_instance()
-
-    @mcp.tool
-    @handle_api_errors()
-    def get_foreign_companies_applying_for_listing(name: str = "", limit: int = 50, offset: int = 0) -> str:
-        """查詢外國公司向證交所申請第一上市之公司。
-
-        Args:
-            name: 公司名稱關鍵字（選填）
-            limit: 回傳筆數上限（預設 50）
-            offset: 跳過前 N 筆（預設 0，搭配 limit 分頁）
-        """
-        data = _client.fetch_data("/company/applylistingForeign")
-        if not data:
-            return MSG_NO_DATA.format(data_type="外國公司申請第一上市")
-
-        if name:
-            data = [d for d in data if name in d.get("Company", "")]
-
-        def formatter(item):
-            code = item.get("Code", "N/A")
-            company_name = item.get("Company", "N/A")
-            application_date = item.get("ApplicationDate", "N/A")
-            approved_date = item.get("ApprovedDate", "N/A")
-            listing_date = item.get("ListingDate", "N/A")
-            return f"- {company_name} ({code}): 申請日期 {application_date}, 核准日期 {approved_date}, 上市日期 {listing_date}\n"
-
-        return format_list_response(data, "外國公司申請第一上市資料", formatter, limit=limit, offset=offset)
-
-    @mcp.tool
-    @handle_api_errors()
-    def get_recently_listed_companies(name: str = "", limit: int = 50, offset: int = 0) -> str:
-        """查詢最近上市公司。
-
-        Args:
-            name: 公司名稱關鍵字（選填）
-            limit: 回傳筆數上限（預設 50）
-            offset: 跳過前 N 筆（預設 0，搭配 limit 分頁）
-        """
-        data = _client.fetch_data("/company/newlisting")
-        if not data:
-            return MSG_NO_DATA.format(data_type="最近上市公司")
-
-        if name:
-            data = [d for d in data if name in d.get("Company", "")]
-
-        def formatter(item):
-            company_code = item.get("Code", "N/A")
-            company_name = item.get("Company", "N/A")
-            listing_date = item.get("ListingDate", "N/A")
-            return f"- {company_name} ({company_code}): 上市日期 {listing_date}\n"
-
-        return format_list_response(data, "最近上市公司資料", formatter, limit=limit, offset=offset)
-
-    @mcp.tool
-    @handle_api_errors()
-    def get_suspended_listed_companies(name: str = "", limit: int = 50, offset: int = 0) -> str:
-        """查詢終止上市公司。
-
-        Args:
-            name: 公司名稱關鍵字（選填）
-            limit: 回傳筆數上限（預設 50）
-            offset: 跳過前 N 筆（預設 0，搭配 limit 分頁）
-        """
-        data = _client.fetch_data("/company/suspendListingCsvAndHtml")
-        if not data:
-            return MSG_NO_DATA.format(data_type="終止上市公司")
-
-        if name:
-            data = [d for d in data if name in d.get("Company", "")]
-
-        def formatter(item):
-            company_code = item.get("Code", "N/A")
-            company_name = item.get("Company", "N/A")
-            delisting_date = item.get("DelistingDate", "N/A")
-            return f"- {company_name} ({company_code}): 終止日期 {delisting_date}\n"
-
-        return format_list_response(data, "終止上市公司資料", formatter, limit=limit, offset=offset)
-
-    @mcp.tool
-    @handle_api_errors()
-    def get_local_companies_applying_for_listing(name: str = "", limit: int = 50, offset: int = 0) -> str:
-        """查詢申請上市之本國公司。
-
-        Args:
-            name: 公司名稱關鍵字（選填）
-            limit: 回傳筆數上限（預設 50）
-            offset: 跳過前 N 筆（預設 0，搭配 limit 分頁）
-        """
-        data = _client.fetch_data("/company/applylistingLocal")
-        if not data:
-            return MSG_NO_DATA.format(data_type="申請上市之本國公司")
-
-        if name:
-            data = [d for d in data if name in d.get("Company", "")]
-
-        def formatter(item):
-            code = item.get("Code", "N/A")
-            company_name = item.get("Company", "N/A")
-            application_date = item.get("ApplicationDate", "N/A")
-            approved_date = item.get("ApprovedDate", "N/A")
-            listing_date = item.get("ListingDate", "N/A")
-            return f"- {company_name} ({code}): 申請日期 {application_date}, 核准日期 {approved_date}, 上市日期 {listing_date}\n"
-
-        return format_list_response(data, "申請上市之本國公司資料", formatter, limit=limit, offset=offset)
+    for endpoint, name, summary, label, empty_type, formatter in LISTING_TOOLS:
+        create_list_tool(
+            mcp, endpoint, name, _doc(summary), label, empty_type,
+            formatter, filter_field="Company", client=client,
+        )

--- a/tools/trading/market.py
+++ b/tools/trading/market.py
@@ -7,159 +7,145 @@ from utils import (
     MSG_NO_DATA,
     handle_api_errors,
     format_list_response,
+    create_list_tool,
 )
+
+
+def _doc(summary: str, has_name: bool, default_limit: int = 50) -> str:
+    """Build a tool docstring in the repo's standard shape."""
+    lines = [summary, "", "        Args:"]
+    if has_name:
+        lines.append("            name: 股票名稱關鍵字（選填）")
+    lines.append(f"            limit: 回傳筆數上限（預設 {default_limit}）")
+    lines.append("            offset: 跳過前 N 筆（預設 0，搭配 limit 分頁）")
+    return "\n".join(lines)
+
+
+# Simple list tools that follow: fetch → optional name filter → paginate.
+# Tuple: (endpoint, name, summary, label, empty_data_type, filter_field, formatter)
+SIMPLE_LIST_TOOLS = [
+    (
+        "/exchangeReport/TWT88U", "get_stocks_no_price_change_first_five_days",
+        "查詢上市個股首五日無漲跌幅。", "上市個股首五日無漲跌幅資料",
+        "上市個股首五日無漲跌幅", "Name",
+        lambda i: f"- {i.get('Name', 'N/A')} ({i.get('Code', 'N/A')}): 承銷價 {i.get('PriceUnderwritten', 'N/A')}\n",
+    ),
+    (
+        "/Announcement/BFZFZU_T", "get_financial_program_abnormal_recommendations",
+        "查詢投資理財節目異常推介個股。", "投資理財節目異常推介個股資料",
+        "投資理財節目異常推介個股", "Name",
+        lambda i: f"- {i.get('Name', 'N/A')} ({i.get('Code', 'N/A')}): {i.get('Number', 'N/A')}\n",
+    ),
+    (
+        "/exchangeReport/TWTB4U", "get_daily_day_trading_targets",
+        "查詢上市股票每日當日沖銷交易標的及統計。", "上市股票每日當日沖銷交易標的資料",
+        "上市股票每日當日沖銷交易標的", "Name",
+        lambda i: f"- {i.get('Name', 'N/A')} ({i.get('Code', 'N/A')}): {i.get('Suspension', 'N/A')}\n",
+    ),
+    (
+        "/exchangeReport/TWTBAU1", "get_suspended_day_trading_announcement",
+        "查詢集中市場暫停先賣後買當日沖銷交易標的預告表。", "集中市場暫停先賣後買當日沖銷交易標的預告表資料",
+        "集中市場暫停先賣後買當日沖銷交易標的預告表", "Name",
+        lambda i: f"- {i.get('Name', 'N/A')} ({i.get('Code', 'N/A')}): 暫停日期 {i.get('StartDate', 'N/A')}\n",
+    ),
+    (
+        "/exchangeReport/TWTBAU2", "get_suspended_day_trading_history",
+        "查詢集中市場暫停先賣後買當日沖銷交易歷史查詢。", "集中市場暫停先賣後買當日沖銷交易歷史資料",
+        "集中市場暫停先賣後買當日沖銷交易歷史", "Name",
+        lambda i: f"- {i.get('Name', 'N/A')} ({i.get('Code', 'N/A')}): 暫停日期 {i.get('StartDate', 'N/A')}\n",
+    ),
+    (
+        "/exchangeReport/MI_INDEX4", "get_cross_market_trading_info",
+        "查詢每日上市上櫃跨市場成交資訊。", "每日上市上櫃跨市場成交資訊",
+        "每日上市上櫃跨市場成交資訊", None,
+        lambda i: f"- {i.get('Date', 'N/A')}: 台灣指數 {i.get('FormosaIndex', 'N/A')} ({i.get('Change', 'N/A')}) 成交金額 {i.get('TradeValue', 'N/A')}\n",
+    ),
+    (
+        "/exchangeReport/TWT53U", "get_odd_lot_trading_quotes",
+        "查詢集中市場零股交易行情單。", "集中市場零股交易行情單資料",
+        "集中市場零股交易行情單", "Name",
+        lambda i: f"- {i.get('Name', 'N/A')} ({i.get('Code', 'N/A')}): 成交價 {i.get('TradePrice', 'N/A')}, 成交量 {i.get('TradeVolume', 'N/A')}\n",
+    ),
+    (
+        "/exchangeReport/TWTAWU", "get_suspended_trading_stocks",
+        "查詢集中市場暫停交易證券。", "集中市場暫停交易證券資料",
+        "集中市場暫停交易證券", "Name",
+        lambda i: f"- {i.get('Name', 'N/A')} ({i.get('Code', 'N/A')}): 停止 {i.get('TradingHaltDate', 'N/A')}, 恢復 {i.get('TradingResumptionDate', 'N/A')}\n",
+    ),
+    (
+        "/exchangeReport/BFI84U", "get_margin_loan_restrictions_announcement",
+        "查詢集中市場停資停券預告表。", "集中市場停資停券預告表資料",
+        "集中市場停資停券預告表", "Name",
+        lambda i: f"- {i.get('Name', 'N/A')} ({i.get('Code', 'N/A')}): {i.get('Reason', 'N/A')}\n",
+    ),
+    (
+        "/block/BFIAUU_d", "get_block_trades_daily",
+        "查詢集中市場鉅額交易日成交量值統計。", "集中市場鉅額交易日成交量值統計資料",
+        "集中市場鉅額交易日成交量值統計", None,
+        lambda i: f"- {i.get('Date', 'N/A')}: 成交量 {i.get('TradeVolume', 'N/A')}, 總成交金額 {i.get('TradeValue', 'N/A')}\n",
+    ),
+    (
+        "/block/BFIAUU_m", "get_block_trades_monthly",
+        "查詢集中市場鉅額交易月成交量值統計。", "集中市場鉅額交易月成交量值統計資料",
+        "集中市場鉅額交易月成交量值統計", None,
+        lambda i: f"- {i.get('Month', 'N/A')}: 成交量 {i.get('TradeVolume', 'N/A')}, 總成交金額 {i.get('TradeValue', 'N/A')}\n",
+    ),
+    (
+        "/block/BFIAUU_y", "get_block_trades_yearly",
+        "查詢集中市場鉅額交易年成交量值統計。", "集中市場鉅額交易年成交量值統計資料",
+        "集中市場鉅額交易年成交量值統計", None,
+        lambda i: f"- {i.get('Month', 'N/A')}: 成交量 {i.get('TradeVolume', 'N/A')}, 總成交金額 {i.get('TradeValue', 'N/A')}\n",
+    ),
+    (
+        "/exchangeReport/STOCK_FIRST", "get_first_listed_foreign_stocks_daily",
+        "查詢每日第一上市外國股票成交量值。", "每日第一上市外國股票成交量值資料",
+        "每日第一上市外國股票成交量值", "Name",
+        lambda i: f"- {i.get('Name', 'N/A')} ({i.get('Code', 'N/A')}): 成交量 {i.get('TradeVolume', 'N/A')}, 成交金額 {i.get('TradeValue', 'N/A')}\n",
+    ),
+    (
+        "/exchangeReport/TWT85U", "get_securities_trading_changes",
+        "查詢集中市場證券變更交易。", "集中市場證券變更交易資料",
+        "集中市場證券變更交易", "Name",
+        lambda i: f"- {i.get('Name', 'N/A')} ({i.get('Code', 'N/A')}): {i.get('PeriodicCallAuctionTrading', 'N/A')}\n",
+    ),
+    (
+        "/exchangeReport/BWIBBU_d", "get_valuation_ratios_by_date",
+        "查詢上市個股日本益比、殖利率及股價淨值比（依日期查詢）。", "上市個股日本益比殖利率及股價淨值比資料",
+        "上市個股日本益比殖利率及股價淨值比", "Name",
+        lambda i: (
+            f"- {i.get('Name', 'N/A')} ({i.get('Code', 'N/A')})\n"
+            f"  本益比: {i.get('PEratio', 'N/A')} | 殖利率: {i.get('DividendYield', 'N/A')}% (股利年度: {i.get('DividendYear', 'N/A')})\n"
+            f"  股價淨值比: {i.get('PBratio', 'N/A')} | 財報季度: {i.get('FiscalYearQuarter', 'N/A')}\n\n"
+        ),
+    ),
+    (
+        "/exchangeReport/TWT84U", "get_stock_price_changes",
+        "查詢上市個股股價升降幅度。", "上市個股股價升降幅度資料",
+        "上市個股股價升降幅度", "Name",
+        lambda i: f"- {i.get('Name', 'N/A')} ({i.get('Code', 'N/A')}): 漲停 {i.get('TodayLimitUp', 'N/A')}, 跌停 {i.get('TodayLimitDown', 'N/A')}\n",
+    ),
+    (
+        "/exchangeReport/FMTQIK", "get_daily_market_trading_info",
+        "查詢集中市場每日市場成交資訊。", "集中市場每日市場成交資訊",
+        "集中市場每日市場成交資訊", None,
+        lambda i: f"- {i.get('Date', 'N/A')}: 成交量 {i.get('TradeVolume', 'N/A')}, 成交金額 {i.get('TradeValue', 'N/A')}, 成交筆數 {i.get('Transaction', 'N/A')}, 加權指數 {i.get('TAIEX', 'N/A')}, 漲跌 {i.get('Change', 'N/A')}\n",
+    ),
+]
+
 
 def register_tools(mcp: FastMCP, client: Optional[TWSEAPIClient] = None) -> None:
     """Register market trading tools with the MCP instance."""
 
     _client = client or TWSEAPIClient.get_instance()
 
-    @mcp.tool
-    @handle_api_errors()
-    def get_stocks_no_price_change_first_five_days(name: str = "", limit: int = 50, offset: int = 0) -> str:
-        """查詢上市個股首五日無漲跌幅。
+    for endpoint, name, summary, label, empty_type, filter_field, formatter in SIMPLE_LIST_TOOLS:
+        create_list_tool(
+            mcp, endpoint, name,
+            _doc(summary, has_name=filter_field is not None),
+            label, empty_type, formatter, filter_field=filter_field, client=client,
+        )
 
-        Args:
-            name: 股票名稱關鍵字（選填）
-            limit: 回傳筆數上限（預設 50）
-            offset: 跳過前 N 筆（預設 0，搭配 limit 分頁）
-        """
-        data = _client.fetch_data("/exchangeReport/TWT88U")
-        if not data:
-            return MSG_NO_DATA.format(data_type="上市個股首五日無漲跌幅")
-
-        if name:
-            data = [d for d in data if name in d.get("Name", "")]
-
-        def formatter(item):
-            stock_code = item.get("Code", "N/A")
-            stock_name = item.get("Name", "N/A")
-            reference_price = item.get("PriceUnderwritten", "N/A")
-            return f"- {stock_name} ({stock_code}): 承銷價 {reference_price}\n"
-
-        return format_list_response(data, "上市個股首五日無漲跌幅資料", formatter, limit=limit, offset=offset)
-
-    @mcp.tool
-    @handle_api_errors()
-    def get_financial_program_abnormal_recommendations(name: str = "", limit: int = 50, offset: int = 0) -> str:
-        """查詢投資理財節目異常推介個股。
-
-        Args:
-            name: 股票名稱關鍵字（選填）
-            limit: 回傳筆數上限（預設 50）
-            offset: 跳過前 N 筆（預設 0，搭配 limit 分頁）
-        """
-        data = _client.fetch_data("/Announcement/BFZFZU_T")
-        if not data:
-            return MSG_NO_DATA.format(data_type="投資理財節目異常推介個股")
-
-        if name:
-            data = [d for d in data if name in d.get("Name", "")]
-
-        def formatter(item):
-            stock_code = item.get("Code", "N/A")
-            stock_name = item.get("Name", "N/A")
-            program_name = item.get("Number", "N/A")
-            return f"- {stock_name} ({stock_code}): {program_name}\n"
-
-        return format_list_response(data, "投資理財節目異常推介個股資料", formatter, limit=limit, offset=offset)
-
-    @mcp.tool
-    @handle_api_errors()
-    def get_daily_day_trading_targets(name: str = "", limit: int = 50, offset: int = 0) -> str:
-        """查詢上市股票每日當日沖銷交易標的及統計。
-
-        Args:
-            name: 股票名稱關鍵字（選填）
-            limit: 回傳筆數上限（預設 50）
-            offset: 跳過前 N 筆（預設 0，搭配 limit 分頁）
-        """
-        data = _client.fetch_data("/exchangeReport/TWTB4U")
-        if not data:
-            return MSG_NO_DATA.format(data_type="上市股票每日當日沖銷交易標的")
-
-        if name:
-            data = [d for d in data if name in d.get("Name", "")]
-
-        def formatter(item):
-            stock_code = item.get("Code", "N/A")
-            stock_name = item.get("Name", "N/A")
-            suspension = item.get("Suspension", "N/A")
-            return f"- {stock_name} ({stock_code}): {suspension}\n"
-
-        return format_list_response(data, "上市股票每日當日沖銷交易標的資料", formatter, limit=limit, offset=offset)
-
-    @mcp.tool
-    @handle_api_errors()
-    def get_suspended_day_trading_announcement(name: str = "", limit: int = 50, offset: int = 0) -> str:
-        """查詢集中市場暫停先賣後買當日沖銷交易標的預告表。
-
-        Args:
-            name: 股票名稱關鍵字（選填）
-            limit: 回傳筆數上限（預設 50）
-            offset: 跳過前 N 筆（預設 0，搭配 limit 分頁）
-        """
-        data = _client.fetch_data("/exchangeReport/TWTBAU1")
-        if not data:
-            return MSG_NO_DATA.format(data_type="集中市場暫停先賣後買當日沖銷交易標的預告表")
-
-        if name:
-            data = [d for d in data if name in d.get("Name", "")]
-
-        def formatter(item):
-            stock_code = item.get("Code", "N/A")
-            stock_name = item.get("Name", "N/A")
-            suspension_date = item.get("StartDate", "N/A")
-            return f"- {stock_name} ({stock_code}): 暫停日期 {suspension_date}\n"
-
-        return format_list_response(data, "集中市場暫停先賣後買當日沖銷交易標的預告表資料", formatter, limit=limit, offset=offset)
-
-    @mcp.tool
-    @handle_api_errors()
-    def get_suspended_day_trading_history(name: str = "", limit: int = 50, offset: int = 0) -> str:
-        """查詢集中市場暫停先賣後買當日沖銷交易歷史查詢。
-
-        Args:
-            name: 股票名稱關鍵字（選填）
-            limit: 回傳筆數上限（預設 50）
-            offset: 跳過前 N 筆（預設 0，搭配 limit 分頁）
-        """
-        data = _client.fetch_data("/exchangeReport/TWTBAU2")
-        if not data:
-            return MSG_NO_DATA.format(data_type="集中市場暫停先賣後買當日沖銷交易歷史")
-
-        if name:
-            data = [d for d in data if name in d.get("Name", "")]
-
-        def formatter(item):
-            stock_code = item.get("Code", "N/A")
-            stock_name = item.get("Name", "N/A")
-            suspension_date = item.get("StartDate", "N/A")
-            return f"- {stock_name} ({stock_code}): 暫停日期 {suspension_date}\n"
-
-        return format_list_response(data, "集中市場暫停先賣後買當日沖銷交易歷史資料", formatter, limit=limit, offset=offset)
-
-    @mcp.tool
-    @handle_api_errors()
-    def get_cross_market_trading_info(limit: int = 50, offset: int = 0) -> str:
-        """查詢每日上市上櫃跨市場成交資訊。
-
-        Args:
-            limit: 回傳筆數上限（預設 50）
-            offset: 跳過前 N 筆（預設 0，搭配 limit 分頁）
-        """
-        data = _client.fetch_data("/exchangeReport/MI_INDEX4")
-        if not data:
-            return MSG_NO_DATA.format(data_type="每日上市上櫃跨市場成交資訊")
-
-        def formatter(item):
-            date = item.get("Date", "N/A")
-            index = item.get("FormosaIndex", "N/A")
-            change = item.get("Change", "N/A")
-            value = item.get("TradeValue", "N/A")
-            return f"- {date}: 台灣指數 {index} ({change}) 成交金額 {value}\n"
-
-        return format_list_response(data, "每日上市上櫃跨市場成交資訊", formatter, limit=limit, offset=offset)
+    # --- Tools with custom headers, branching, or multi-section output ---
 
     @mcp.tool
     @handle_api_errors()
@@ -217,58 +203,6 @@ def register_tools(mcp: FastMCP, client: Optional[TWSEAPIClient] = None) -> None
 
     @mcp.tool
     @handle_api_errors()
-    def get_odd_lot_trading_quotes(name: str = "", limit: int = 50, offset: int = 0) -> str:
-        """查詢集中市場零股交易行情單。
-
-        Args:
-            name: 股票名稱關鍵字（選填）
-            limit: 回傳筆數上限（預設 50）
-            offset: 跳過前 N 筆（預設 0，搭配 limit 分頁）
-        """
-        data = _client.fetch_data("/exchangeReport/TWT53U")
-        if not data:
-            return MSG_NO_DATA.format(data_type="集中市場零股交易行情單")
-
-        if name:
-            data = [d for d in data if name in d.get("Name", "")]
-
-        def formatter(item):
-            stock_code = item.get("Code", "N/A")
-            stock_name = item.get("Name", "N/A")
-            price = item.get("TradePrice", "N/A")
-            volume = item.get("TradeVolume", "N/A")
-            return f"- {stock_name} ({stock_code}): 成交價 {price}, 成交量 {volume}\n"
-
-        return format_list_response(data, "集中市場零股交易行情單資料", formatter, limit=limit, offset=offset)
-
-    @mcp.tool
-    @handle_api_errors()
-    def get_suspended_trading_stocks(name: str = "", limit: int = 50, offset: int = 0) -> str:
-        """查詢集中市場暫停交易證券。
-
-        Args:
-            name: 股票名稱關鍵字（選填）
-            limit: 回傳筆數上限（預設 50）
-            offset: 跳過前 N 筆（預設 0，搭配 limit 分頁）
-        """
-        data = _client.fetch_data("/exchangeReport/TWTAWU")
-        if not data:
-            return MSG_NO_DATA.format(data_type="集中市場暫停交易證券")
-
-        if name:
-            data = [d for d in data if name in d.get("Name", "")]
-
-        def formatter(item):
-            stock_code = item.get("Code", "N/A")
-            stock_name = item.get("Name", "N/A")
-            halt_date = item.get("TradingHaltDate", "N/A")
-            resumption_date = item.get("TradingResumptionDate", "N/A")
-            return f"- {stock_name} ({stock_code}): 停止 {halt_date}, 恢復 {resumption_date}\n"
-
-        return format_list_response(data, "集中市場暫停交易證券資料", formatter, limit=limit, offset=offset)
-
-    @mcp.tool
-    @handle_api_errors()
     def get_after_hours_trading(code: str = "", limit: int = 50, offset: int = 0) -> str:
         """查詢集中市場盤後定價交易。
 
@@ -317,204 +251,6 @@ def register_tools(mcp: FastMCP, client: Optional[TWSEAPIClient] = None) -> None
             return f"- {stock_name} ({stock_code})\n  成交價: {trade_price} | 成交量: {trade_volume} | 成交金額: {trade_value}\n"
 
         return format_list_response(traded_data, "集中市場盤後定價交易資料", formatter, limit=limit, offset=offset)
-
-    @mcp.tool
-    @handle_api_errors()
-    def get_margin_loan_restrictions_announcement(name: str = "", limit: int = 50, offset: int = 0) -> str:
-        """查詢集中市場停資停券預告表。
-
-        Args:
-            name: 股票名稱關鍵字（選填）
-            limit: 回傳筆數上限（預設 50）
-            offset: 跳過前 N 筆（預設 0，搭配 limit 分頁）
-        """
-        data = _client.fetch_data("/exchangeReport/BFI84U")
-        if not data:
-            return MSG_NO_DATA.format(data_type="集中市場停資停券預告表")
-
-        if name:
-            data = [d for d in data if name in d.get("Name", "")]
-
-        def formatter(item):
-            stock_code = item.get("Code", "N/A")
-            stock_name = item.get("Name", "N/A")
-            restriction_type = item.get("Reason", "N/A")
-            return f"- {stock_name} ({stock_code}): {restriction_type}\n"
-
-        return format_list_response(data, "集中市場停資停券預告表資料", formatter, limit=limit, offset=offset)
-
-    @mcp.tool
-    @handle_api_errors()
-    def get_block_trades_daily(limit: int = 50, offset: int = 0) -> str:
-        """查詢集中市場鉅額交易日成交量值統計。
-
-        Args:
-            limit: 回傳筆數上限（預設 50）
-            offset: 跳過前 N 筆（預設 0，搭配 limit 分頁）
-        """
-        data = _client.fetch_data("/block/BFIAUU_d")
-        if not data:
-            return MSG_NO_DATA.format(data_type="集中市場鉅額交易日成交量值統計")
-
-        def formatter(item):
-            date = item.get("Date", "N/A")
-            volume = item.get("TradeVolume", "N/A")
-            total_value = item.get("TradeValue", "N/A")
-            return f"- {date}: 成交量 {volume}, 總成交金額 {total_value}\n"
-
-        return format_list_response(data, "集中市場鉅額交易日成交量值統計資料", formatter, limit=limit, offset=offset)
-
-    @mcp.tool
-    @handle_api_errors()
-    def get_block_trades_monthly(limit: int = 50, offset: int = 0) -> str:
-        """查詢集中市場鉅額交易月成交量值統計。
-
-        Args:
-            limit: 回傳筆數上限（預設 50）
-            offset: 跳過前 N 筆（預設 0，搭配 limit 分頁）
-        """
-        data = _client.fetch_data("/block/BFIAUU_m")
-        if not data:
-            return MSG_NO_DATA.format(data_type="集中市場鉅額交易月成交量值統計")
-
-        def formatter(item):
-            month = item.get("Month", "N/A")
-            volume = item.get("TradeVolume", "N/A")
-            total_value = item.get("TradeValue", "N/A")
-            return f"- {month}: 成交量 {volume}, 總成交金額 {total_value}\n"
-
-        return format_list_response(data, "集中市場鉅額交易月成交量值統計資料", formatter, limit=limit, offset=offset)
-
-    @mcp.tool
-    @handle_api_errors()
-    def get_block_trades_yearly(limit: int = 50, offset: int = 0) -> str:
-        """查詢集中市場鉅額交易年成交量值統計。
-
-        Args:
-            limit: 回傳筆數上限（預設 50）
-            offset: 跳過前 N 筆（預設 0，搭配 limit 分頁）
-        """
-        data = _client.fetch_data("/block/BFIAUU_y")
-        if not data:
-            return MSG_NO_DATA.format(data_type="集中市場鉅額交易年成交量值統計")
-
-        def formatter(item):
-            year = item.get("Month", "N/A")
-            volume = item.get("TradeVolume", "N/A")
-            total_value = item.get("TradeValue", "N/A")
-            return f"- {year}: 成交量 {volume}, 總成交金額 {total_value}\n"
-
-        return format_list_response(data, "集中市場鉅額交易年成交量值統計資料", formatter, limit=limit, offset=offset)
-
-    @mcp.tool
-    @handle_api_errors()
-    def get_first_listed_foreign_stocks_daily(name: str = "", limit: int = 50, offset: int = 0) -> str:
-        """查詢每日第一上市外國股票成交量值。
-
-        Args:
-            name: 股票名稱關鍵字（選填）
-            limit: 回傳筆數上限（預設 50）
-            offset: 跳過前 N 筆（預設 0，搭配 limit 分頁）
-        """
-        data = _client.fetch_data("/exchangeReport/STOCK_FIRST")
-        if not data:
-            return MSG_NO_DATA.format(data_type="每日第一上市外國股票成交量值")
-
-        if name:
-            data = [d for d in data if name in d.get("Name", "")]
-
-        def formatter(item):
-            stock_code = item.get("Code", "N/A")
-            stock_name = item.get("Name", "N/A")
-            volume = item.get("TradeVolume", "N/A")
-            value = item.get("TradeValue", "N/A")
-            return f"- {stock_name} ({stock_code}): 成交量 {volume}, 成交金額 {value}\n"
-
-        return format_list_response(data, "每日第一上市外國股票成交量值資料", formatter, limit=limit, offset=offset)
-
-    @mcp.tool
-    @handle_api_errors()
-    def get_securities_trading_changes(name: str = "", limit: int = 50, offset: int = 0) -> str:
-        """查詢集中市場證券變更交易。
-
-        Args:
-            name: 股票名稱關鍵字（選填）
-            limit: 回傳筆數上限（預設 50）
-            offset: 跳過前 N 筆（預設 0，搭配 limit 分頁）
-        """
-        data = _client.fetch_data("/exchangeReport/TWT85U")
-        if not data:
-            return MSG_NO_DATA.format(data_type="集中市場證券變更交易")
-
-        if name:
-            data = [d for d in data if name in d.get("Name", "")]
-
-        def formatter(item):
-            stock_code = item.get("Code", "N/A")
-            stock_name = item.get("Name", "N/A")
-            change_type = item.get("PeriodicCallAuctionTrading", "N/A")
-            return f"- {stock_name} ({stock_code}): {change_type}\n"
-
-        return format_list_response(data, "集中市場證券變更交易資料", formatter, limit=limit, offset=offset)
-
-    @mcp.tool
-    @handle_api_errors()
-    def get_valuation_ratios_by_date(name: str = "", limit: int = 50, offset: int = 0) -> str:
-        """查詢上市個股日本益比、殖利率及股價淨值比（依日期查詢）。
-
-        Args:
-            name: 股票名稱關鍵字（選填）
-            limit: 回傳筆數上限（預設 50）
-            offset: 跳過前 N 筆（預設 0，搭配 limit 分頁）
-        """
-        data = _client.fetch_data("/exchangeReport/BWIBBU_d")
-        if not data:
-            return MSG_NO_DATA.format(data_type="上市個股日本益比殖利率及股價淨值比")
-
-        if name:
-            data = [d for d in data if name in d.get("Name", "")]
-
-        def formatter(item):
-            stock_code = item.get("Code", "N/A")
-            stock_name = item.get("Name", "N/A")
-            dividend_yield = item.get("DividendYield", "N/A")
-            dividend_year = item.get("DividendYear", "N/A")
-            pe_ratio = item.get("PEratio", "N/A")
-            pb_ratio = item.get("PBratio", "N/A")
-            fiscal_year_quarter = item.get("FiscalYearQuarter", "N/A")
-            return (
-                f"- {stock_name} ({stock_code})\n"
-                f"  本益比: {pe_ratio} | 殖利率: {dividend_yield}% (股利年度: {dividend_year})\n"
-                f"  股價淨值比: {pb_ratio} | 財報季度: {fiscal_year_quarter}\n\n"
-            )
-
-        return format_list_response(data, "上市個股日本益比殖利率及股價淨值比資料", formatter, limit=limit, offset=offset)
-
-    @mcp.tool
-    @handle_api_errors()
-    def get_stock_price_changes(name: str = "", limit: int = 50, offset: int = 0) -> str:
-        """查詢上市個股股價升降幅度。
-
-        Args:
-            name: 股票名稱關鍵字（選填）
-            limit: 回傳筆數上限（預設 50）
-            offset: 跳過前 N 筆（預設 0，搭配 limit 分頁）
-        """
-        data = _client.fetch_data("/exchangeReport/TWT84U")
-        if not data:
-            return MSG_NO_DATA.format(data_type="上市個股股價升降幅度")
-
-        if name:
-            data = [d for d in data if name in d.get("Name", "")]
-
-        def formatter(item):
-            stock_code = item.get("Code", "N/A")
-            stock_name = item.get("Name", "N/A")
-            limit_up = item.get("TodayLimitUp", "N/A")
-            limit_down = item.get("TodayLimitDown", "N/A")
-            return f"- {stock_name} ({stock_code}): 漲停 {limit_up}, 跌停 {limit_down}\n"
-
-        return format_list_response(data, "上市個股股價升降幅度資料", formatter, limit=limit, offset=offset)
 
     @mcp.tool
     @handle_api_errors()
@@ -613,30 +349,6 @@ def register_tools(mcp: FastMCP, client: Optional[TWSEAPIClient] = None) -> None
             )
 
         return format_list_response(valid_data, "集中市場當日公布注意股票資料", formatter, limit=limit, offset=offset)
-
-    @mcp.tool
-    @handle_api_errors()
-    def get_daily_market_trading_info(limit: int = 50, offset: int = 0) -> str:
-        """查詢集中市場每日市場成交資訊。
-
-        Args:
-            limit: 回傳筆數上限（預設 50）
-            offset: 跳過前 N 筆（預設 0，搭配 limit 分頁）
-        """
-        data = _client.fetch_data("/exchangeReport/FMTQIK")
-        if not data:
-            return MSG_NO_DATA.format(data_type="集中市場每日市場成交資訊")
-
-        def formatter(item):
-            date = item.get("Date", "N/A")
-            trade_volume = item.get("TradeVolume", "N/A")
-            trade_value = item.get("TradeValue", "N/A")
-            transaction = item.get("Transaction", "N/A")
-            taiex = item.get("TAIEX", "N/A")
-            change = item.get("Change", "N/A")
-            return f"- {date}: 成交量 {trade_volume}, 成交金額 {trade_value}, 成交筆數 {transaction}, 加權指數 {taiex}, 漲跌 {change}\n"
-
-        return format_list_response(data, "集中市場每日市場成交資訊", formatter, limit=limit, offset=offset)
 
     @mcp.tool
     @handle_api_errors()

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -21,7 +21,7 @@ from .formatters import (
     format_list_response,
     create_simple_list_formatter,
 )
-from .tool_factory import create_company_tool
+from .tool_factory import create_company_tool, create_list_tool
 from .date_helper import roc_to_ad, ad_to_roc
 
 __all__ = [
@@ -46,6 +46,7 @@ __all__ = [
     "format_list_response",
     "create_simple_list_formatter",
     "create_company_tool",
+    "create_list_tool",
     "roc_to_ad",
     "ad_to_roc",
 ]

--- a/utils/tool_factory.py
+++ b/utils/tool_factory.py
@@ -2,8 +2,14 @@
 
 from typing import Callable, Optional
 from fastmcp import FastMCP
-from utils import TWSEAPIClient, format_properties_with_values_multiline
+from utils import (
+    TWSEAPIClient,
+    MSG_NO_DATA,
+    format_list_response,
+    format_properties_with_values_multiline,
+)
 from utils.decorators import handle_api_errors
+from utils.types import DataFormatter
 
 def create_company_tool(mcp: FastMCP, endpoint: str, name: str, docstring: str, client: Optional[TWSEAPIClient] = None) -> Callable[[str], str]:
     """
@@ -27,5 +33,63 @@ def create_company_tool(mcp: FastMCP, endpoint: str, name: str, docstring: str, 
 
     tool_fn.__name__ = name
     decorated = handle_api_errors(use_code_param=True)(tool_fn)
+    mcp.tool(name=name, description=docstring)(decorated)
+    return decorated
+
+
+def create_list_tool(
+    mcp: FastMCP,
+    endpoint: str,
+    name: str,
+    docstring: str,
+    label: str,
+    empty_data_type: str,
+    formatter: DataFormatter,
+    filter_field: Optional[str] = None,
+    client: Optional[TWSEAPIClient] = None,
+) -> Callable[..., str]:
+    """
+    Create and register a standard list-style market/company query tool.
+
+    Collapses the ubiquitous "fetch list → optional name filter → paginate"
+    boilerplate. The per-tool rendering rule is supplied as ``formatter``
+    (Strategy), while everything else is declared via the arguments below.
+
+    Args:
+        mcp: FastMCP instance
+        endpoint: TWSE API endpoint (passed to ``fetch_data``)
+        name: Function name for the registered tool
+        docstring: Tool description (also the MCP schema description)
+        label: Header label passed to ``format_list_response``
+        empty_data_type: ``data_type`` for the MSG_NO_DATA message when the
+            source returns no rows at all
+        formatter: Per-item rendering function (the Strategy)
+        filter_field: When set, the tool exposes a ``name`` keyword that
+            substring-filters rows on this field; when None, the tool only
+            exposes ``limit``/``offset``
+        client: TWSEAPIClient instance for dependency injection
+
+    Returns:
+        The registered tool function
+    """
+    _client = client or TWSEAPIClient.get_instance()
+
+    def _render(data, filter_value: str, limit: int, offset: int) -> str:
+        if not data:
+            return MSG_NO_DATA.format(data_type=empty_data_type)
+        if filter_field and filter_value:
+            data = [d for d in data if filter_value in d.get(filter_field, "")]
+        return format_list_response(data, label, formatter, limit=limit, offset=offset)
+
+    if filter_field:
+        def tool_fn(name: str = "", limit: int = 50, offset: int = 0) -> str:
+            return _render(_client.fetch_data(endpoint), name, limit, offset)
+    else:
+        def tool_fn(limit: int = 50, offset: int = 0) -> str:
+            return _render(_client.fetch_data(endpoint), "", limit, offset)
+
+    tool_fn.__name__ = name
+    tool_fn.__doc__ = docstring
+    decorated = handle_api_errors()(tool_fn)
     mcp.tool(name=name, description=docstring)(decorated)
     return decorated


### PR DESCRIPTION
## Summary

Collapses the most-repeated pattern in the codebase — *fetch list → optional name filter → paginate* — into a single `create_list_tool` factory. This is the `list_tool` factory foreshadowed in Phase 2.

**Design patterns applied:**
- **Factory Method** — `create_list_tool` mirrors the existing `create_company_tool`; tools are declared in a table instead of hand-written.
- **Strategy** — each tool's per-item rendering is passed as a `formatter` (trivial cases inline as lambdas; conditional rendering as named module functions).
- **Declarative registry** — endpoint/label/filter-field/formatter live in a data table, not duplicated control flow.

## Line reduction (tool code)

| File | Before | After |
|------|--------|-------|
| `tools/trading/market.py` | 683 | 395 |
| `tools/broker.py` | 235 | 84 |
| `tools/company/basic_info.py` | 503 | 425 |
| `tools/company/listing.py` | 119 | 58 |

~578 fewer lines of tool code; factory adds ~63 lines in `utils/tool_factory.py`.

## Scope discipline

Only the genuinely uniform tools were table-driven. Tools with custom headers (`get_top_20_volume_stocks`), code-branching (`get_after_hours_trading`), `has_meaningful_data` pre-filters, non-paginated output, or multi-section rendering (`get_daily_securities_lending_volume`) were **intentionally kept explicit** — forcing them into the factory would obscure rather than clarify.

## Verification — byte-for-byte

Captured all 154 tool outputs against the live TWSE/TPEx API before and after the refactor:

```
0 changed / 154 tools
```

The refactor is provably behavior-preserving — output, pagination, and empty-data messages are identical. This is a pure internal restructuring; the AI-facing tool behavior is unchanged.

## Test plan

- [x] All 154 tools register successfully
- [x] Byte-for-byte output snapshot diff: 0 changes
- [ ] CI schema tests run on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)