### PR TITLE
feat(otc): expand TPEx coverage from 3 to 10 tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ uv sync && uv run fastmcp dev server.py
 | [TWSE OpenAPI](https://openapi.twse.com.tw) | 台灣證交所官方 API — 公司治理、ESG、財報、交易、指數等 | 143 個 |
 | [TWSE Web API](https://www.twse.com.tw) | 證交所網頁 API — 個股日K、月均價、估值、融資融券、上市三大法人買賣超 | 6 個 |
 | [MIS 即時報價](https://mis.twse.com.tw) | 盤中即時多股報價（上市+上櫃） | 1 個 |
-| [TPEx OpenAPI](https://www.tpex.org.tw/openapi) | 櫃買中心 — 上櫃日收盤、三大法人、本益比 | 3 個 |
+| [TPEx OpenAPI](https://www.tpex.org.tw/openapi) | 櫃買中心 — 上櫃日收盤、三大法人（個股/彙總）、本益比、融資融券、注意/處置股、除權息、零股、指數 | 10 個 |
 | [TAIFEX OpenAPI](https://openapi.taifex.com.tw) | 期交所 — 三大法人系列、大額交易人部位、每日行情、選擇權分析、保證金、年月統計 | 16 個 |
 
 ## 🤝 參與貢獻

--- a/README_en-us.md
+++ b/README_en-us.md
@@ -104,7 +104,7 @@ uv sync && uv run fastmcp dev server.py
 | [TWSE OpenAPI](https://openapi.twse.com.tw) | Taiwan Stock Exchange official API — corporate governance, ESG, financials, trading, indices, etc. | 143 |
 | [TWSE Web API](https://www.twse.com.tw) | TWSE web API endpoints — daily OHLC, monthly avg price, valuation, margin balance, listed stocks institutional investors | 6 |
 | [MIS Real-time Quotes](https://mis.twse.com.tw) | Intraday real-time multi-stock quotes (listed + OTC) | 1 |
-| [TPEx OpenAPI](https://www.tpex.org.tw/openapi) | TPEx OTC market — daily close, institutional investors, P/E ratio | 3 |
+| [TPEx OpenAPI](https://www.tpex.org.tw/openapi) | TPEx OTC market — daily close, institutional investors (per-stock/summary), P/E ratio, margin balance, warning/disposal stocks, ex-rights/dividends, odd-lot, index | 10 |
 | [TAIFEX OpenAPI](https://openapi.taifex.com.tw) | TAIFEX derivatives — institutional series, large traders OI, daily market report, options analytics, margin, statistics | 16 |
 
 ## 🤝 Contributing

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,6 @@
 import pytest
 import logging
 import time
-
 from utils.config import TestConfig, APIConfig
 
 # 設定測試日誌
@@ -14,6 +13,7 @@ logging.basicConfig(
 
 # 使用集中管理的配置
 TEST_DELAY = TestConfig.TEST_DELAY
+
 
 @pytest.fixture
 def sample_stock_code():

--- a/tests/e2e/test_otc_api.py
+++ b/tests/e2e/test_otc_api.py
@@ -1,6 +1,7 @@
 """測試 tpex.org.tw/openapi 上櫃 API。只驗證 tool 會 crash 的寫死欄位。"""
 
-from utils.api_client import TWSEAPIClient
+import pytest
+from tests.helpers import fetch_or_skip
 
 TPEX_BASE = "https://www.tpex.org.tw/openapi/v1"
 
@@ -8,13 +9,8 @@ TPEX_BASE = "https://www.tpex.org.tw/openapi/v1"
 class TestOTCDailyCloseAPI:
     """Tool get_otc_daily 用 SecuritiesCompanyCode 做篩選，消失會讓篩選失效。"""
 
-    def test_api_returns_data_with_filter_key(self):
-        result = TWSEAPIClient.get_json(f"{TPEX_BASE}/tpex_mainboard_daily_close_quotes")
-        assert isinstance(result, list) and len(result) > 0
-        assert "SecuritiesCompanyCode" in result[0]
-
     def test_hardcoded_fields_exist(self):
-        result = TWSEAPIClient.get_json(f"{TPEX_BASE}/tpex_mainboard_daily_close_quotes")
+        result = fetch_or_skip(f"{TPEX_BASE}/tpex_mainboard_daily_close_quotes")
         assert isinstance(result, list) and len(result) > 0
         first = result[0]
         required = ["SecuritiesCompanyCode", "CompanyName", "Close", "Change", "Open", "High", "Low", "TradingShares"]
@@ -29,13 +25,8 @@ class TestOTCDailyCloseAPI:
 class TestOTCInstitutionalAPI:
     """Tool get_otc_institutional 用 SecuritiesCompanyCode 做篩選。"""
 
-    def test_api_returns_data_with_filter_key(self):
-        result = TWSEAPIClient.get_json(f"{TPEX_BASE}/tpex_3insti_daily_trading")
-        assert isinstance(result, list) and len(result) > 0
-        assert "SecuritiesCompanyCode" in result[0]
-
     def test_hardcoded_fields_exist(self):
-        result = TWSEAPIClient.get_json(f"{TPEX_BASE}/tpex_3insti_daily_trading")
+        result = fetch_or_skip(f"{TPEX_BASE}/tpex_3insti_daily_trading")
         assert isinstance(result, list) and len(result) > 0
         first = result[0]
         required = [
@@ -57,13 +48,8 @@ class TestOTCInstitutionalAPI:
 class TestOTCValuationAPI:
     """Tool get_otc_valuation 用 SecuritiesCompanyCode 做篩選。"""
 
-    def test_api_returns_data_with_filter_key(self):
-        result = TWSEAPIClient.get_json(f"{TPEX_BASE}/tpex_mainboard_peratio_analysis")
-        assert isinstance(result, list) and len(result) > 0
-        assert "SecuritiesCompanyCode" in result[0]
-
     def test_hardcoded_fields_exist(self):
-        result = TWSEAPIClient.get_json(f"{TPEX_BASE}/tpex_mainboard_peratio_analysis")
+        result = fetch_or_skip(f"{TPEX_BASE}/tpex_mainboard_peratio_analysis")
         assert isinstance(result, list) and len(result) > 0
         first = result[0]
         # YieldRatio or DividendYield — tool tries YieldRatio first, falls back to DividendYield
@@ -75,4 +61,118 @@ class TestOTCValuationAPI:
             f"Missing base fields: {missing}\n"
             f"YieldRatio present: {'YieldRatio' in first}, DividendYield present: {'DividendYield' in first}\n"
             f"Actual fields: {sorted(first.keys())}"
+        )
+
+
+class TestOTCMarginBalanceAPI:
+    """Tool get_otc_margin_balance 用 SecuritiesCompanyCode 篩選，3 個數值欄位顯示。"""
+
+    def test_hardcoded_fields_exist(self):
+        result = fetch_or_skip(f"{TPEX_BASE}/tpex_mainboard_margin_balance")
+        assert isinstance(result, list) and len(result) > 0
+        first = result[0]
+        required = [
+            "SecuritiesCompanyCode", "CompanyName",
+            "MarginPurchaseBalance", "ShortSaleBalance", "MarginPurchaseUtilizationRate",
+        ]
+        missing = [f for f in required if f not in first]
+        assert not missing, (
+            f"tpex_mainboard_margin_balance removed fields that get_otc_margin_balance uses.\n"
+            f"Missing: {missing}\nActual fields: {sorted(first.keys())}"
+        )
+
+
+class TestOTCTradingWarningAPI:
+    """Tool get_otc_warning_stocks 顯示注意事由與收盤價。"""
+
+    def test_hardcoded_fields_exist(self):
+        result = fetch_or_skip(f"{TPEX_BASE}/tpex_trading_warning_information")
+        assert isinstance(result, list) and len(result) > 0
+        first = result[0]
+        required = ["SecuritiesCompanyCode", "CompanyName", "TradingInformation", "ClosePrice"]
+        missing = [f for f in required if f not in first]
+        assert not missing, (
+            f"tpex_trading_warning_information removed fields that get_otc_warning_stocks uses.\n"
+            f"Missing: {missing}\nActual fields: {sorted(first.keys())}"
+        )
+
+
+class TestOTCDisposalAPI:
+    """Tool get_otc_disposal_stocks 顯示處置期間與原因。"""
+
+    def test_hardcoded_fields_exist(self):
+        result = fetch_or_skip(f"{TPEX_BASE}/tpex_disposal_information")
+        assert isinstance(result, list) and len(result) > 0
+        first = result[0]
+        required = ["SecuritiesCompanyCode", "CompanyName", "DispositionPeriod", "DispositionReasons"]
+        missing = [f for f in required if f not in first]
+        assert not missing, (
+            f"tpex_disposal_information removed fields that get_otc_disposal_stocks uses.\n"
+            f"Missing: {missing}\nActual fields: {sorted(first.keys())}"
+        )
+
+
+class TestOTCExrightAPI:
+    """Tool get_otc_exright 顯示除權息各欄位。"""
+
+    def test_hardcoded_fields_exist(self):
+        result = fetch_or_skip(f"{TPEX_BASE}/tpex_exright_daily")
+        # May be empty on non-trading or non-exright days — skip rather than fail
+        if not isinstance(result, list) or not result:
+            pytest.skip("tpex_exright_daily returned no data today (no ex-rights/dividends)")
+        first = result[0]
+        required = [
+            "SecuritiesCompanyCode", "CompanyName",
+            "ClosePriceBeforeExRightsDiviend", "ExRightsDiviendQuote",
+            "StockDividend", "CashDividend", "ExRightsDiviend",
+        ]
+        missing = [f for f in required if f not in first]
+        assert not missing, (
+            f"tpex_exright_daily removed fields that get_otc_exright uses.\n"
+            f"Missing: {missing}\nActual fields: {sorted(first.keys())}"
+        )
+
+
+class TestOTCOddLotAPI:
+    """Tool get_otc_odd_lot 顯示零股價格與成交資料。"""
+
+    def test_hardcoded_fields_exist(self):
+        result = fetch_or_skip(f"{TPEX_BASE}/tpex_odd_stock")
+        assert isinstance(result, list) and len(result) > 0
+        first = result[0]
+        required = ["SecuritiesCompanyCode", "CompanyName", "TradeVolume", "Price", "TradeAmount"]
+        missing = [f for f in required if f not in first]
+        assert not missing, (
+            f"tpex_odd_stock removed fields that get_otc_odd_lot uses.\n"
+            f"Missing: {missing}\nActual fields: {sorted(first.keys())}"
+        )
+
+
+class TestOTCIndexAPI:
+    """Tool get_otc_index 顯示開高低收漲跌。"""
+
+    def test_hardcoded_fields_exist(self):
+        result = fetch_or_skip(f"{TPEX_BASE}/tpex_index")
+        assert isinstance(result, list) and len(result) > 0
+        first = result[0]
+        required = ["Date", "Open", "High", "Low", "Close", "Change"]
+        missing = [f for f in required if f not in first]
+        assert not missing, (
+            f"tpex_index removed fields that get_otc_index uses.\n"
+            f"Missing: {missing}\nActual fields: {sorted(first.keys())}"
+        )
+
+
+class TestOTCInstitutionalSummaryAPI:
+    """Tool get_otc_institutional_summary 顯示三大法人彙總買賣超。"""
+
+    def test_hardcoded_fields_exist(self):
+        result = fetch_or_skip(f"{TPEX_BASE}/tpex_3insti_summary")
+        assert isinstance(result, list) and len(result) > 0
+        first = result[0]
+        required = ["Date", "Investor", "PurchaseAmount", "SaleAmount", "Net"]
+        missing = [f for f in required if f not in first]
+        assert not missing, (
+            f"tpex_3insti_summary removed fields that get_otc_institutional_summary uses.\n"
+            f"Missing: {missing}\nActual fields: {sorted(first.keys())}"
         )

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,0 +1,17 @@
+"""Shared test helpers for e2e API tests."""
+
+import pytest
+import requests
+from utils.api_client import TWSEAPIClient
+
+
+def fetch_or_skip(url: str, **kwargs):
+    """Fetch URL; skip test on upstream 5xx or connection error. 404 still FAILs."""
+    try:
+        return TWSEAPIClient.get_json(url, **kwargs)
+    except requests.HTTPError as e:
+        if e.response is not None and e.response.status_code >= 500:
+            pytest.skip(f"Upstream server error ({e.response.status_code}): {url}")
+        raise
+    except requests.ConnectionError as e:
+        pytest.skip(f"Cannot reach upstream: {url} — {e}")

--- a/tools/otc/exright.py
+++ b/tools/otc/exright.py
@@ -1,0 +1,50 @@
+"""OTC ex-rights / ex-dividend daily data from TPEx openapi."""
+
+from typing import Optional
+from fastmcp import FastMCP
+from utils import TWSEAPIClient, handle_api_errors, DEFAULT_DISPLAY_LIMIT
+
+TPEX_EXRIGHT_URL = "https://www.tpex.org.tw/openapi/v1/tpex_exright_daily"
+
+
+def register_tools(mcp: FastMCP, client: Optional[TWSEAPIClient] = None) -> None:
+    """Register OTC ex-rights/dividends tools."""
+    _client = client or TWSEAPIClient.get_instance()
+
+    @mcp.tool
+    @handle_api_errors()
+    def get_otc_exright(stock_no: str = "") -> str:
+        """查詢今日上櫃除權息股票，包含除權息基準價、股票股利、現金股利。
+        可指定股票代號查詢特定股票。
+
+        Args:
+            stock_no: 股票代號（選填），若指定則只回傳該股票資料
+
+        Returns:
+            除權息股票代號、名稱、除權息前收盤、除權息參考價、股票股利、現金股利、類型
+        """
+        data = _client.fetch_json(TPEX_EXRIGHT_URL)
+
+        if not isinstance(data, list) or not data:
+            return "今日無上櫃除權息股票資料"
+
+        if stock_no:
+            data = [d for d in data if d.get("SecuritiesCompanyCode", "").strip() == stock_no]
+            if not data:
+                return f"上櫃股票代號 {stock_no} 今日無除權息"
+
+        lines = [f"【上櫃今日除權息】（共 {len(data)} 筆）\n"]
+        for item in data:
+            code = item.get("SecuritiesCompanyCode", "?")
+            name = item.get("CompanyName", "?")
+            before = item.get("ClosePriceBeforeExRightsDiviend", "-")
+            ref = item.get("ExRightsDiviendQuote", "-")
+            stock_div = item.get("StockDividend", "-")
+            cash_div = item.get("CashDividend", "-")
+            ex_type = item.get("ExRightsDiviend", "-")
+            lines.append(
+                f"{code} {name} | 類型: {ex_type} | 前收: {before} | 參考價: {ref} "
+                f"| 股利: {stock_div} | 現金: {cash_div}"
+            )
+
+        return "\n".join(lines)

--- a/tools/otc/index.py
+++ b/tools/otc/index.py
@@ -1,0 +1,54 @@
+"""OTC (TPEx) market index data from TPEx openapi."""
+
+from typing import Optional
+from fastmcp import FastMCP
+from utils import TWSEAPIClient, handle_api_errors, DEFAULT_DISPLAY_LIMIT
+
+TPEX_INDEX_URL = "https://www.tpex.org.tw/openapi/v1/tpex_index"
+
+
+def register_tools(mcp: FastMCP, client: Optional[TWSEAPIClient] = None) -> None:
+    """Register OTC index tools."""
+    _client = client or TWSEAPIClient.get_instance()
+
+    @mcp.tool
+    @handle_api_errors()
+    def get_otc_index(limit: int = DEFAULT_DISPLAY_LIMIT, offset: int = 0) -> str:
+        """查詢櫃買市場（上櫃）指數歷史行情，包含開高低收、漲跌幅。
+
+        Args:
+            limit: 回傳筆數上限（預設 50）
+            offset: 跳過前 N 筆（預設 0，搭配 limit 分頁）
+
+        Returns:
+            櫃買指數各期日期、開盤、最高、最低、收盤、漲跌
+        """
+        data = _client.fetch_json(TPEX_INDEX_URL)
+
+        if not isinstance(data, list) or not data:
+            return "查無櫃買指數資料"
+
+        total = len(data)
+        page_data = data[offset:offset + limit]
+        end = min(offset + limit, total)
+
+        header = f"【櫃買市場指數】（共 {total} 筆"
+        if total > limit or offset > 0:
+            header += f"，顯示第 {offset + 1}–{end} 筆"
+        header += "）\n"
+
+        lines = [header]
+        for item in page_data:
+            date = item.get("Date", "?")
+            open_p = item.get("Open", "-")
+            high = item.get("High", "-")
+            low = item.get("Low", "-")
+            close = item.get("Close", "-")
+            change = item.get("Change", "-")
+            lines.append(f"{date} | 開: {open_p} | 高: {high} | 低: {low} | 收: {close} | 漲跌: {change}")
+
+        remaining = total - offset - limit
+        if remaining > 0:
+            lines.append(f"\n...還有 {remaining} 筆，使用 offset={offset + limit} 查看更多")
+
+        return "\n".join(lines)

--- a/tools/otc/institutional_summary.py
+++ b/tools/otc/institutional_summary.py
@@ -1,0 +1,37 @@
+"""OTC institutional investors summary (三大法人彙總) from TPEx openapi."""
+
+from typing import Optional
+from fastmcp import FastMCP
+from utils import TWSEAPIClient, handle_api_errors
+
+TPEX_3INSTI_SUMMARY_URL = "https://www.tpex.org.tw/openapi/v1/tpex_3insti_summary"
+
+
+def register_tools(mcp: FastMCP, client: Optional[TWSEAPIClient] = None) -> None:
+    """Register OTC institutional summary tools."""
+    _client = client or TWSEAPIClient.get_instance()
+
+    @mcp.tool
+    @handle_api_errors()
+    def get_otc_institutional_summary() -> str:
+        """查詢上櫃市場三大法人（外資、投信、自營商）當日買賣超彙總，顯示整體市場層面的法人動向。
+        與 get_otc_institutional（個股明細）互補。
+
+        Returns:
+            外資、投信、自營商各類別的買進金額、賣出金額、買賣超淨額
+        """
+        data = _client.fetch_json(TPEX_3INSTI_SUMMARY_URL)
+
+        if not isinstance(data, list) or not data:
+            return "查無上櫃三大法人彙總資料"
+
+        date = data[0].get("Date", "?")
+        lines = [f"【上櫃三大法人彙總】日期: {date}\n"]
+        for item in data:
+            investor = item.get("Investor", "?")
+            buy = item.get("PurchaseAmount", "-")
+            sell = item.get("SaleAmount", "-")
+            net = item.get("Net", "-")
+            lines.append(f"{investor} | 買進: {buy} | 賣出: {sell} | 買賣超: {net}")
+
+        return "\n".join(lines)

--- a/tools/otc/margin_balance.py
+++ b/tools/otc/margin_balance.py
@@ -1,0 +1,62 @@
+"""OTC margin balance (融資融券) from TPEx openapi."""
+
+from typing import Optional
+from fastmcp import FastMCP
+from utils import TWSEAPIClient, handle_api_errors, DEFAULT_DISPLAY_LIMIT
+
+TPEX_MARGIN_URL = "https://www.tpex.org.tw/openapi/v1/tpex_mainboard_margin_balance"
+
+
+def register_tools(mcp: FastMCP, client: Optional[TWSEAPIClient] = None) -> None:
+    """Register OTC margin balance tools."""
+    _client = client or TWSEAPIClient.get_instance()
+
+    @mcp.tool
+    @handle_api_errors()
+    def get_otc_margin_balance(stock_no: str = "", limit: int = DEFAULT_DISPLAY_LIMIT, offset: int = 0) -> str:
+        """查詢上櫃股票融資融券餘額，包含融資餘額、融券餘額、融資使用率。
+        可指定股票代號只查單一個股。與上市版 get_margin_balance 對應。
+
+        Args:
+            stock_no: 股票代號（選填），若指定則只回傳該股票的融資融券資料
+            limit: 回傳筆數上限（預設 50）
+            offset: 跳過前 N 筆（預設 0，搭配 limit 分頁；指定 stock_no 時忽略）
+
+        Returns:
+            每支上櫃股的融資餘額、融券餘額、融資使用率等資料
+        """
+        data = _client.fetch_json(TPEX_MARGIN_URL)
+
+        if not isinstance(data, list) or not data:
+            return "查無上櫃市場融資融券餘額資料"
+
+        if stock_no:
+            data = [d for d in data if d.get("SecuritiesCompanyCode", "").strip() == stock_no]
+            if not data:
+                return f"查無上櫃股票代號 {stock_no} 的融資融券資料"
+
+        total = len(data)
+        page_data = data[offset:offset + limit]
+        end = min(offset + limit, total)
+
+        header = f"【上櫃融資融券餘額】（共 {total} 筆"
+        if total > limit or offset > 0:
+            header += f"，顯示第 {offset + 1}–{end} 筆"
+        header += "）\n"
+
+        lines = [header]
+        for item in page_data:
+            code = item.get("SecuritiesCompanyCode", "?")
+            name = item.get("CompanyName", "?")
+            margin_bal = item.get("MarginPurchaseBalance", "-")
+            short_bal = item.get("ShortSaleBalance", "-")
+            util_rate = item.get("MarginPurchaseUtilizationRate", "-")
+            lines.append(
+                f"{code} {name} | 融資餘額: {margin_bal} | 融券餘額: {short_bal} | 融資使用率: {util_rate}%"
+            )
+
+        remaining = total - offset - limit
+        if remaining > 0 and not stock_no:
+            lines.append(f"\n...還有 {remaining} 筆，使用 offset={offset + limit} 查看更多")
+
+        return "\n".join(lines)

--- a/tools/otc/odd_lot.py
+++ b/tools/otc/odd_lot.py
@@ -1,0 +1,60 @@
+"""OTC odd-lot (零股) trading data from TPEx openapi."""
+
+from typing import Optional
+from fastmcp import FastMCP
+from utils import TWSEAPIClient, handle_api_errors, DEFAULT_DISPLAY_LIMIT
+
+TPEX_ODD_LOT_URL = "https://www.tpex.org.tw/openapi/v1/tpex_odd_stock"
+
+
+def register_tools(mcp: FastMCP, client: Optional[TWSEAPIClient] = None) -> None:
+    """Register OTC odd-lot trading tools."""
+    _client = client or TWSEAPIClient.get_instance()
+
+    @mcp.tool
+    @handle_api_errors()
+    def get_otc_odd_lot(stock_no: str = "", limit: int = DEFAULT_DISPLAY_LIMIT, offset: int = 0) -> str:
+        """查詢上櫃零股（不足一張）交易行情，包含零股成交價、成交量、成交金額。
+        可指定股票代號只查單一個股。
+
+        Args:
+            stock_no: 股票代號（選填），若指定則只回傳該股票的零股資料
+            limit: 回傳筆數上限（預設 50）
+            offset: 跳過前 N 筆（預設 0，搭配 limit 分頁；指定 stock_no 時忽略）
+
+        Returns:
+            每支上櫃股的零股成交價、成交股數、成交金額、最佳買/賣價
+        """
+        data = _client.fetch_json(TPEX_ODD_LOT_URL)
+
+        if not isinstance(data, list) or not data:
+            return "查無上櫃零股交易資料"
+
+        if stock_no:
+            data = [d for d in data if d.get("SecuritiesCompanyCode", "").strip() == stock_no]
+            if not data:
+                return f"查無上櫃股票代號 {stock_no} 的零股交易資料"
+
+        total = len(data)
+        page_data = data[offset:offset + limit]
+        end = min(offset + limit, total)
+
+        header = f"【上櫃零股交易行情】（共 {total} 筆"
+        if total > limit or offset > 0:
+            header += f"，顯示第 {offset + 1}–{end} 筆"
+        header += "）\n"
+
+        lines = [header]
+        for item in page_data:
+            code = item.get("SecuritiesCompanyCode", "?")
+            name = item.get("CompanyName", "?")
+            price = item.get("Price", "-")
+            volume = item.get("TradeVolume", "-")
+            amount = item.get("TradeAmount", "-")
+            lines.append(f"{code} {name} | 價: {price} | 股數: {volume} | 金額: {amount}")
+
+        remaining = total - offset - limit
+        if remaining > 0 and not stock_no:
+            lines.append(f"\n...還有 {remaining} 筆，使用 offset={offset + limit} 查看更多")
+
+        return "\n".join(lines)

--- a/tools/otc/trading_halt.py
+++ b/tools/otc/trading_halt.py
@@ -1,0 +1,77 @@
+"""OTC trading warning and disposal stocks from TPEx openapi."""
+
+from typing import Optional
+from fastmcp import FastMCP
+from utils import TWSEAPIClient, handle_api_errors, DEFAULT_DISPLAY_LIMIT
+
+TPEX_WARNING_URL = "https://www.tpex.org.tw/openapi/v1/tpex_trading_warning_information"
+TPEX_DISPOSAL_URL = "https://www.tpex.org.tw/openapi/v1/tpex_disposal_information"
+
+
+def register_tools(mcp: FastMCP, client: Optional[TWSEAPIClient] = None) -> None:
+    """Register OTC trading warning and disposal tools."""
+    _client = client or TWSEAPIClient.get_instance()
+
+    @mcp.tool
+    @handle_api_errors()
+    def get_otc_warning_stocks(stock_no: str = "") -> str:
+        """查詢上櫃注意股票，列出當前被列為交易注意的上櫃股票及其警示原因。
+        可指定股票代號查詢特定股票是否在注意名單。
+
+        Args:
+            stock_no: 股票代號（選填），若指定則只回傳該股票資料
+
+        Returns:
+            注意股票代號、名稱、注意事由、收盤價、本益比
+        """
+        data = _client.fetch_json(TPEX_WARNING_URL)
+
+        if not isinstance(data, list) or not data:
+            return "目前無上櫃注意股票資料"
+
+        if stock_no:
+            data = [d for d in data if d.get("SecuritiesCompanyCode", "").strip() == stock_no]
+            if not data:
+                return f"上櫃股票代號 {stock_no} 目前不在注意名單"
+
+        lines = [f"【上櫃注意股票】（共 {len(data)} 筆）\n"]
+        for item in data:
+            code = item.get("SecuritiesCompanyCode", "?")
+            name = item.get("CompanyName", "?")
+            info = item.get("TradingInformation", "-")
+            close = item.get("ClosePrice", "-")
+            lines.append(f"{code} {name} | 收盤: {close} | 注意事由: {info}")
+
+        return "\n".join(lines)
+
+    @mcp.tool
+    @handle_api_errors()
+    def get_otc_disposal_stocks(stock_no: str = "") -> str:
+        """查詢上櫃處置股票，列出當前被列為交易處置的上櫃股票、處置期間及原因。
+        可指定股票代號查詢特定股票是否在處置名單。
+
+        Args:
+            stock_no: 股票代號（選填），若指定則只回傳該股票資料
+
+        Returns:
+            處置股票代號、名稱、處置期間、處置原因、處置條件
+        """
+        data = _client.fetch_json(TPEX_DISPOSAL_URL)
+
+        if not isinstance(data, list) or not data:
+            return "目前無上櫃處置股票資料"
+
+        if stock_no:
+            data = [d for d in data if d.get("SecuritiesCompanyCode", "").strip() == stock_no]
+            if not data:
+                return f"上櫃股票代號 {stock_no} 目前不在處置名單"
+
+        lines = [f"【上櫃處置股票】（共 {len(data)} 筆）\n"]
+        for item in data:
+            code = item.get("SecuritiesCompanyCode", "?")
+            name = item.get("CompanyName", "?")
+            period = item.get("DispositionPeriod", "-")
+            reasons = item.get("DispositionReasons", "-")
+            lines.append(f"{code} {name} | 處置期間: {period} | 原因: {reasons}")
+
+        return "\n".join(lines)


### PR DESCRIPTION
## Summary

- Add 7 new OTC tools from `tpex.org.tw/openapi`: margin balance, warning stocks, disposal stocks, ex-rights/dividends, odd-lot trading, OTC index, institutional summary
- Add `tests/helpers.py` with `fetch_or_skip()` — converts upstream 5xx to `pytest.skip`, preventing false-positive CI issue creation on TPEx outages; 404 still FAILs
- Remove redundant `test_api_returns_data_with_filter_key` tests from existing OTC test classes
- Update README (zh/en) TPEx tool count 3 → 10

## Test plan

- [ ] `uv run pytest tests/e2e/test_otc_api.py -v` — 10 passed
- [ ] All 7 new test classes have `test_hardcoded_fields_exist` guarding hardcoded field names
- [ ] `tpex_exright_daily` skips gracefully on non-ex-rights days (empty response)

🤖 Generated with [Claude Code](https://claude.com/claude-code)