### PR TITLE
Use shared upstream skip helper for TAIFEX E2E tests

### DIFF
--- a/tests/e2e/test_taifex_api.py
+++ b/tests/e2e/test_taifex_api.py
@@ -1,6 +1,6 @@
 """測試 openapi.taifex.com.tw 期交所 API。只驗證 tool 寫死的欄位。"""
 
-import requests
+from tests.helpers import fetch_or_skip
 
 # TAIFEX requires browser-like User-Agent
 HEADERS = {
@@ -10,11 +10,10 @@ HEADERS = {
 
 
 def _fetch(endpoint: str) -> list:
-    resp = requests.get(
+    return fetch_or_skip(
         f"https://openapi.taifex.com.tw/v1/{endpoint}",
-        headers=HEADERS, verify=False, timeout=15,
+        headers=HEADERS, timeout=15,
     )
-    return resp.json()
 
 
 class TestFuturesInstitutionalAPI:

--- a/tests/e2e/test_taifex_batch2_api.py
+++ b/tests/e2e/test_taifex_batch2_api.py
@@ -1,6 +1,6 @@
 """測試第二批新增 TAIFEX API 工具端點。只驗證 tool 寫死的欄位存在。"""
 
-import requests
+from tests.helpers import fetch_or_skip
 
 HEADERS = {
     "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36",
@@ -9,11 +9,10 @@ HEADERS = {
 
 
 def _fetch(endpoint: str) -> list:
-    resp = requests.get(
+    return fetch_or_skip(
         f"https://openapi.taifex.com.tw/v1/{endpoint}",
-        headers=HEADERS, verify=False, timeout=15,
+        headers=HEADERS, timeout=15,
     )
-    return resp.json()
 
 
 class TestInstitutionalTradersByFuturesAPI:

--- a/tests/e2e/test_taifex_new_api.py
+++ b/tests/e2e/test_taifex_new_api.py
@@ -1,7 +1,7 @@
 """測試新增的 TAIFEX API 工具端點。只驗證 tool 寫死的欄位存在，不驗證動態欄位。"""
 
 import pytest
-import requests
+from tests.helpers import fetch_or_skip
 
 HEADERS = {
     "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36",
@@ -10,11 +10,10 @@ HEADERS = {
 
 
 def _fetch(endpoint: str) -> list:
-    resp = requests.get(
+    return fetch_or_skip(
         f"https://openapi.taifex.com.tw/v1/{endpoint}",
-        headers=HEADERS, verify=False, timeout=15,
+        headers=HEADERS, timeout=15,
     )
-    return resp.json()
 
 
 @pytest.fixture(scope="class")

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -9,7 +9,7 @@ from utils.api_client import TWSEAPIClient
 def fetch_or_skip(url: str, **kwargs):
     """Fetch URL; skip test on upstream 5xx, empty body, or connection error. 404 still FAILs."""
     try:
-        return TWSEAPIClient.get_json(url, **kwargs)
+        return TWSEAPIClient.get_instance().fetch_json(url, **kwargs)
     except requests.HTTPError as e:
         if e.response is not None and e.response.status_code >= 500:
             pytest.skip(f"Upstream server error ({e.response.status_code}): {url}")


### PR DESCRIPTION
## Summary
- route TAIFEX E2E API fetches through the existing `fetch_or_skip` helper
- allow the helper to pass headers/timeouts through `TWSEAPIClient.fetch_json`
- keep schema/key assertions as failures while skipping transient upstream non-JSON/server responses consistently with other E2E tests

## Context
Issue #37 was opened from a scheduled E2E run where one TAIFEX endpoint raised `JSONDecodeError`. The endpoint currently returns JSON for me, so this does not change the expected field checks; it only makes TAIFEX tests use the same upstream-failure handling already used by TWSE/TPEX tests.

## Verification
- `uv sync --extra dev`
- `uv run pytest tests/e2e/test_taifex_batch2_api.py::TestInstitutionalTradersByFuturesAPI::test_hardcoded_fields_exist -q`
- `uv run pytest tests/e2e/test_taifex_api.py -q`
- `uv run pytest tests/e2e/test_realtime_api.py tests/e2e/test_history_api.py::TestStockDayAPI::test_date_field_is_roc_format -q`
- `uv run pytest tests/e2e/test_taifex_api.py tests/e2e/test_taifex_new_api.py tests/e2e/test_taifex_batch2_api.py -q`

Full modified TAIFEX run: 27 passed, with existing upstream TLS warnings.