### PR TITLE
perf: cache OpenAPI list responses in TWSEAPIClient

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,10 @@
 # Set to true to enable SSL verification (may fail with TWSE API)
 # TWSE_VERIFY_SSL=false
 
+# TTL (seconds) for the in-memory OpenAPI list-response cache
+# Set to 0 to disable caching
+# TWSE_CACHE_TTL=60
+
 # ===== Display Configuration =====
 
 # Default number of records to display in list responses

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,6 +90,7 @@ All configuration in `utils/config.py` reads from environment variables with sen
 - `TWSE_REQUEST_INTERVAL` (default: `0.5` seconds)
 - `TWSE_API_TIMEOUT` (default: `30.0` seconds)
 - `TWSE_VERIFY_SSL` (default: `false` — required for TWSE API compatibility)
+- `TWSE_CACHE_TTL` (default: `60` seconds — in-memory cache for `fetch_data` OpenAPI list responses; `0` disables)
 - `DISPLAY_LIMIT` (default: `20`)
 - `PYTEST_DELAY_SECONDS` (default: `1.0` — rate limit delay between tests)
 

--- a/utils/api_client.py
+++ b/utils/api_client.py
@@ -16,17 +16,20 @@ class TWSEAPIClient:
     # Global instance for backward compatibility
     _instance: Optional['TWSEAPIClient'] = None
     
-    def __init__(self, 
-                 base_url: str = APIConfig.BASE_URL, 
+    def __init__(self,
+                 base_url: str = APIConfig.BASE_URL,
                  user_agent: str = APIConfig.USER_AGENT,
                  request_interval: float = APIConfig.REQUEST_INTERVAL,
-                 verify_ssl: bool = APIConfig.VERIFY_SSL):
+                 verify_ssl: bool = APIConfig.VERIFY_SSL,
+                 cache_ttl: float = APIConfig.CACHE_TTL):
         """Initialize the API client."""
         self.base_url = base_url
         self.user_agent = user_agent
         self.request_interval = request_interval
         self.verify_ssl = verify_ssl
+        self.cache_ttl = cache_ttl
         self._last_request_time = 0.0
+        self._cache: Dict[str, tuple[float, List[TWSEDataItem]]] = {}
 
     @classmethod
     def get_instance(cls) -> 'TWSEAPIClient':
@@ -66,8 +69,20 @@ class TWSEAPIClient:
         return resp
 
     def fetch_data(self, endpoint: str, timeout: float = APIConfig.DEFAULT_TIMEOUT) -> List[TWSEDataItem]:
-        """Fetch from a TWSE OpenAPI endpoint (base_url-relative) and normalise to a list."""
+        """Fetch from a TWSE OpenAPI endpoint (base_url-relative) and normalise to a list.
+
+        Results are cached in-memory per endpoint for ``self.cache_ttl`` seconds. OpenAPI
+        list endpoints (company profiles, financials, governance, etc.) change at most daily,
+        but a single prompt often triggers several tools that read the same full list within
+        seconds of each other — the cache turns those into one HTTP round-trip.
+        """
         url = f"{self.base_url}{endpoint}"
+
+        if self.cache_ttl > 0:
+            cached = self._cache.get(url)
+            if cached is not None and time.time() - cached[0] < self.cache_ttl:
+                return cached[1]
+
         try:
             resp = self._request(url, timeout=timeout)
             try:
@@ -75,7 +90,10 @@ class TWSEAPIClient:
             except Exception as parse_err:
                 logger.warning(f"Response is not valid JSON for {url}: {parse_err}; returning empty list")
                 return []
-            return data if isinstance(data, list) else ([data] if data else [])
+            result = data if isinstance(data, list) else ([data] if data else [])
+            if self.cache_ttl > 0:
+                self._cache[url] = (time.time(), result)
+            return result
         except Exception as e:
             logger.error(f"Failed to fetch data from {url}: {e}")
             raise

--- a/utils/config.py
+++ b/utils/config.py
@@ -40,6 +40,15 @@ class APIConfig:
         'false'
     ).lower() in ('true', '1', 'yes')
 
+    # TTL (seconds) for the in-memory OpenAPI list-response cache in TWSEAPIClient.fetch_data.
+    # A single prompt often triggers several tools that hit the same endpoint (e.g. multiple
+    # company-lookup tools reading the same full company list) within seconds of each other;
+    # this avoids re-downloading the whole list for each one. Set to 0 to disable caching.
+    CACHE_TTL: Final[float] = float(os.getenv(
+        'TWSE_CACHE_TTL',
+        '60'
+    ))
+
 
 class DisplayConfig:
     """Display and formatting configuration."""


### PR DESCRIPTION
## Summary
- `fetch_company_data()` calls `fetch_data()` which re-downloads the **entire** endpoint (often 1000+ company rows) and filters client-side, for every single company lookup. There's no caching anywhere in the client.
- A single prompt commonly chains several company tools (`get_company_profile`, `get_company_dividend`, `get_company_monthly_revenue`, ...) — each hits a *different* endpoint, but tools that repeat within a session (or across close-together requests for the same field) redundantly re-fetch the same list.
- Added a short-TTL in-memory cache to `TWSEAPIClient.fetch_data()`, keyed by resolved URL. Default 60s, configurable via `TWSE_CACHE_TTL` env var, `0` disables it entirely.
- Scoped to `fetch_data` (TWSE OpenAPI, base_url-relative) only — does **not** touch `fetch_json` (MIS realtime quotes, legacy `exchangeReport`, TPEx, TAIFEX), so nothing time-sensitive gets accidentally cached.
- OpenAPI list endpoints here (company profiles, governance, financials) update at most daily per TWSE, so a 60s cache carries effectively no staleness risk while collapsing repeated full-list downloads within a burst of tool calls into one HTTP round-trip.

## Test plan
- [x] `python -m py_compile utils/api_client.py utils/config.py`
- [x] Manual check with a mocked `_request`: two `fetch_data()` calls to the same endpoint within the TTL window produce 1 HTTP call and return the same cached list; setting `cache_ttl=0` disables caching (each call re-fetches)
- [x] Confirmed `TWSEAPIClient.get_instance()` picks up `TWSE_CACHE_TTL` default (60.0) via `APIConfig`