### PR TITLE
docs: localize prompt templates, remove fabricated example data

### DIFF
--- a/prompts/dividend_investment_strategy_prompt.py
+++ b/prompts/dividend_investment_strategy_prompt.py
@@ -4,117 +4,117 @@ from fastmcp.prompts.prompt import PromptMessage, TextContent
 
 
 def dividend_investment_strategy_prompt(strategy_type: str = "high_yield", time_horizon: str = "quarterly") -> PromptMessage:
-    """Prompt for dividend investment strategy using TWSE OpenAPI endpoints.""" 
-    content = f"""Dividend Investment Strategy for Taiwan Stock Market:
+    """Prompt for dividend investment strategy using TWSE OpenAPI endpoints."""
+    content = f"""台灣股市股利投資策略指引
 
-You are a Taiwan stock market dividend investment expert. Use the following TWSE OpenAPI endpoints to develop comprehensive dividend investment strategies:
+你是台灣股市股利投資策略專家。呼叫下方 TWSE OpenAPI 工具，制定完整的股利投資策略。
 
-### Available APIs for Dividend Analysis:
+⚠️ 重要：以下工具用途與輸出格式僅為使用指引與骨架。任何殖利率、日期或個股排名皆只是格式示意，絕非真實資料。實際分析前必須先呼叫對應工具取得當下真實回傳資料；分析內容與結論只能依據工具實際回傳的數據撰寫，不可憑空臆測或沿用範本中的示意數字。若查無資料，應如實說明。
 
-**Dividend Scheduling & Planning:**
-- `get_dividend_rights_schedule(code)`: Ex-dividend dates and dividend amounts
-- `get_company_dividend(code)`: Historical dividend distribution data
-- `get_stock_valuation_ratios(code)`: P/E ratios, dividend yields, P/B ratios
+### 股利分析可用工具：
 
-**Fundamental Analysis:**
-- `get_company_profile(code)`: Company basic information and industry classification
-- `get_company_monthly_revenue(code)`: Revenue trends supporting dividend sustainability
-- `get_company_income_statement(code)`: Earnings data for payout ratio analysis
-- `get_company_balance_sheet(code)`: Financial strength assessment
+**除權息排程與規劃：**
+- `get_dividend_rights_schedule(code)`：除權息日期與股利金額
+- `get_company_dividend(code)`：歷史股利發放資料
+- `get_stock_valuation_ratios(code)`：本益比、殖利率、股價淨值比
 
-**Market Validation:**
-- `get_top_foreign_holdings()`: Foreign investor dividend stock preferences  
-- `get_etf_regular_investment_ranking()`: Popular dividend-focused investment trends
-- `get_stock_daily_trading(code)`: Price stability around ex-dividend dates
+**基本面分析：**
+- `get_company_profile(code)`：公司基本資料與產業分類
+- `get_company_monthly_revenue(code)`：支撐配息永續性的營收趨勢
+- `get_company_income_statement(code)`：計算配息率所需的獲利資料
+- `get_company_balance_sheet(code)`：財務體質評估
 
-### Investment Strategy Types:
+**市場驗證：**
+- `get_top_foreign_holdings()`：外資偏好的股利股
+- `get_etf_regular_investment_ranking()`：熱門定期定額投資標的
+- `get_stock_daily_trading(code)`：除權息前後的股價穩定度
 
-**1. High Yield Strategy (strategy_type="high_yield"):**
-Focus on stocks with attractive dividend yields:
-- Use `get_stock_valuation_ratios()` to identify high dividend yield stocks (>4%)
-- Validate sustainability with `get_company_income_statement()` and revenue trends
-- Check `get_dividend_rights_schedule()` for upcoming distributions
-- Assess foreign interest via `get_top_foreign_holdings()`
+### 投資策略類型：
 
-**2. Dividend Growth Strategy (strategy_type="growth"):**
-Target companies with consistent dividend increases:
-- Analyze `get_company_dividend()` for historical dividend growth patterns
-- Cross-reference with `get_company_monthly_revenue()` for business growth
-- Use `get_company_balance_sheet()` to ensure financial strength
-- Monitor foreign investment trends as quality validation
+**1. 高殖利率策略（strategy_type="high_yield"）：**
+鎖定殖利率具吸引力的個股：
+- 呼叫 `get_stock_valuation_ratios()`，依實際回傳資料篩選高殖利率個股
+- 以 `get_company_income_statement()` 與營收趨勢驗證配息永續性
+- 呼叫 `get_dividend_rights_schedule()` 確認即將發放的股利
+- 以 `get_top_foreign_holdings()` 評估外資關注度
 
-**3. Ex-Dividend Timing Strategy (strategy_type="timing"):**
-Optimize entry/exit around ex-dividend dates:
-- Use `get_dividend_rights_schedule()` for precise timing
-- Analyze `get_stock_daily_trading()` for historical price patterns
-- Consider `get_stock_valuation_ratios()` for fair value assessment
-- Factor in upcoming dividend announcements
+**2. 股利成長策略（strategy_type="growth"）：**
+鎖定股利持續成長的公司：
+- 分析 `get_company_dividend()` 的歷史股利成長軌跡
+- 對照 `get_company_monthly_revenue()` 確認營收成長支撐
+- 以 `get_company_balance_sheet()` 確認財務體質穩健
+- 觀察外資投資趨勢作為品質驗證
 
-**4. Sector Dividend Strategy (strategy_type="sector"):**
-Focus on dividend-paying sectors:
-- Group companies by industry via `get_company_profile()`
-- Compare sector dividend yields and sustainability
-- Analyze foreign investor sector preferences
-- Diversify across stable dividend-paying industries
+**3. 除權息時機策略（strategy_type="timing"）：**
+優化除權息前後的進出場時機：
+- 呼叫 `get_dividend_rights_schedule()` 掌握精確時程
+- 分析 `get_stock_daily_trading()` 的歷史價格型態
+- 以 `get_stock_valuation_ratios()` 評估合理價位
+- 納入即將公告的股利資訊
 
-### Time Horizon Analysis:
+**4. 產業股利策略（strategy_type="sector"）：**
+鎖定配息穩定的產業：
+- 透過 `get_company_profile()` 依產業分類個股
+- 比較各產業殖利率與配息永續性
+- 分析外資的產業偏好
+- 於穩定配息產業間分散布局
 
-**Quarterly Focus ({time_horizon}="quarterly"):**
-- Next 3 months' ex-dividend schedule
-- Quarterly earnings impact on dividend sustainability
-- Short-term price movements around ex-dates
+### 時間週期分析：
 
-**Annual Planning ({time_horizon}="annual"):**
-- Full year dividend calendar planning
-- Annual dividend growth trend analysis
-- Long-term sector rotation strategies
+**季度視角（time_horizon="quarterly"）：**
+- 未來 3 個月除權息排程
+- 季度獲利對配息永續性的影響
+- 除息日前後的短期價格波動
 
-### Analysis Framework:
+**年度規劃（time_horizon="annual"）：**
+- 全年除權息行事曆規劃
+- 年度股利成長趨勢分析
+- 長期產業輪動策略
 
-**Step 1: Dividend Screening**
-- Screen for target dividend yields or growth rates
-- Verify upcoming ex-dividend dates and amounts
-- Check historical dividend consistency
+### 分析流程：
 
-**Step 2: Fundamental Validation**  
-- Assess earnings coverage and payout ratios
-- Review revenue stability and growth trends
-- Analyze balance sheet strength and cash flow
+**步驟一：股利篩選**
+- 依目標殖利率或成長率篩選
+- 確認即將到來的除權息日期與金額
+- 檢視歷史配息穩定度
 
-**Step 3: Market Positioning**
-- Compare with foreign investment preferences
-- Monitor popular dividend investment trends
-- Assess market timing and valuation levels
+**步驟二：基本面驗證**
+- 評估獲利覆蓋率與配息率
+- 檢視營收穩定度與成長趨勢
+- 分析資產負債結構與現金流
 
-### Output Format:
+**步驟三：市場定位**
+- 對照外資投資偏好
+- 觀察熱門股利投資趨勢
+- 評估市場時機與估值水位
 
-**📊 Dividend Investment Recommendations:**
+### 輸出格式骨架（僅示意結構，不含真實數字）：
 
-**Top Dividend Stocks:**
-1. **Company (Code)**: Yield X%, Ex-date: Date, Rationale
-2. **Company (Code)**: Yield X%, Ex-date: Date, Rationale
+**📊 股利投資建議：**
 
-**📅 Dividend Calendar (Next 3 Months):**
-- Week 1: Companies going ex-dividend, expected yields
-- Week 2: Companies going ex-dividend, expected yields  
-- [Continue for planning horizon]
+**優選股利股：**
+1. **[公司名稱]（[代號]）**：殖利率 [依工具回傳]、除息日 [依工具回傳]、選股理由
+2. ...
 
-**🎯 Strategy Insights:**
-- **Risk Assessment**: Dividend sustainability factors
-- **Entry Timing**: Optimal purchase windows
-- **Portfolio Construction**: Diversification recommendations
-- **Market Conditions**: Current dividend environment analysis
+**📅 除權息行事曆（未來 3 個月）：**
+- 依 `get_dividend_rights_schedule()` 實際回傳資料，依週別列出除權息個股與預估殖利率
 
-**💡 Advanced Strategies:**
-- Dividend capture opportunities  
-- Sector rotation based on dividend cycles
-- Tax optimization considerations
-- Foreign investment flow implications
+**🎯 策略洞察：**
+- **風險評估**：配息永續性因子
+- **進場時機**：合適的買進時間窗
+- **投資組合建構**：分散配置建議
+- **市場環境**：當前股利投資環境分析
 
-### Current Strategy Request:
-Strategy Type: {strategy_type}
-Time Horizon: {time_horizon}
+**💡 進階策略：**
+- 除權息套利機會
+- 依股利週期進行的產業輪動
+- 稅務考量
+- 外資流向的意涵
 
-Please provide comprehensive dividend investment strategy using the appropriate APIs above.
+### 本次策略請求：
+策略類型：{strategy_type}
+時間週期：{time_horizon}
+
+請先呼叫上述對應工具取得真實資料，再依實際回傳內容提供完整的股利投資策略。
 """
     return PromptMessage(role="user", content=TextContent(type="text", text=content))

--- a/prompts/foreign_investment_analysis_prompt.py
+++ b/prompts/foreign_investment_analysis_prompt.py
@@ -5,70 +5,69 @@ from fastmcp.prompts.prompt import PromptMessage, TextContent
 
 def foreign_investment_analysis_prompt(analysis_type: str = "overview", industry: str = "", stock_symbol: str = "") -> PromptMessage:
     """Prompt for foreign investment analysis using TWSE OpenAPI endpoints."""
-    content = f"""Foreign Investment Analysis for Taiwan Stock Market:
+    content = f"""台灣股市外資投資分析指引
 
-You are a Taiwan stock market foreign investment expert. Based on the analysis type requested, use the following TWSE OpenAPI endpoints to provide comprehensive foreign investment insights:
+你是台灣股市外資投資分析專家。根據使用者要求的分析類型，呼叫下方 TWSE OpenAPI 工具，提供外資投資相關的深入分析。
 
-### Available APIs and their purposes:
+⚠️ 重要：以下工具用途與輸出格式僅為使用指引與骨架。任何百分比、公司排名或具體數字皆只是格式示意，絕非真實資料。實際分析前必須先呼叫對應工具取得當下真實回傳資料；分析內容與結論只能依據工具實際回傳的數據撰寫，不可憑空臆測、外插或沿用範本中的示意數字。若查無資料，應如實說明。
 
-**Foreign Investment Overview:**
-- `get_foreign_investment_by_industry()`: Foreign investment holding ratios by industry category
-- `get_top_foreign_holdings()`: Top 20 companies by foreign investment holdings
-- `get_company_profile(code)`: Company basic information for context
+### 可用工具與用途：
 
-**Enhanced Analysis:**
-- `get_market_index_info(category, count, format)`: Market context and sector performance
-  - Use `category="sector", format="summary"` for industry performance context
-  - Use `category="major", count=5, format="simple"` for overall market sentiment
-- `get_company_dividend(code)`: Dividend information for foreign-favored stocks
-- `get_stock_valuation_ratios(code)`: P/E, dividend yield, P/B ratios
-- `get_company_monthly_revenue(code)`: Revenue performance data
+**外資投資總覽：**
+- `get_foreign_investment_by_industry()`：各產業外資持股比例
+- `get_top_foreign_holdings()`：外資持股前 20 大公司
+- `get_company_profile(code)`：公司基本資料（提供背景脈絡）
 
-### Analysis Types:
+**進階分析：**
+- `get_market_index_info(category, count, format)`：市場環境與類股表現
+  - `category="sector", format="summary"`：產業表現總覽
+  - `category="major", count=5, format="simple"`：大盤整體情緒
+- `get_company_dividend(code)`：外資偏好個股的股利資訊
+- `get_stock_valuation_ratios(code)`：本益比、殖利率、股價淨值比
+- `get_company_monthly_revenue(code)`：營收表現資料
 
-**1. Industry Analysis (analysis_type="industry"):**
-Use `get_foreign_investment_by_industry()` to analyze:
-- Which industries attract the most foreign investment
-- Foreign holding percentages by sector
-- Number of companies per industry with foreign investment
-- Industry-specific investment patterns
+### 分析類型：
 
-**2. Top Holdings Analysis (analysis_type="top_holdings"):**
-Use `get_top_foreign_holdings()` and `get_company_profile()` to analyze:
-- Top 20 companies by foreign investment holdings
-- Available investment capacity vs current holdings
-- Investment upper limits and restrictions
-- Company profiles of foreign-favored stocks
+**1. 產業分析（analysis_type="industry"）：**
+呼叫 `get_foreign_investment_by_industry()`，依實際回傳資料分析：
+- 哪些產業吸引最多外資投資
+- 各產業實際外資持股比例
+- 各產業中有外資投資的公司家數
+- 產業別投資型態
 
-**3. Specific Stock Analysis (analysis_type="stock", provide stock_symbol):**
-Combine multiple APIs for stock_symbol analysis:
-- Foreign investment position and limits
-- Company fundamentals and dividend policy
-- Valuation metrics compared to foreign investment trends
+**2. 前 20 大持股分析（analysis_type="top_holdings"）：**
+呼叫 `get_top_foreign_holdings()` 與 `get_company_profile()`，依實際回傳資料分析：
+- 外資持股前 20 大公司名單
+- 可投資空間 vs 目前持股水位
+- 投資上限與限制
+- 外資偏好個股的公司概況
 
-### Example Output Format:
+**3. 個股分析（analysis_type="stock"，需提供 stock_symbol）：**
+綜合呼叫多個工具分析 stock_symbol：
+- 外資持股水位與投資上限
+- 公司基本面與股利政策
+- 估值指標與外資投資趨勢的對照
 
-**Foreign Investment Industry Analysis:**
-- **Technology Sector**: 45.2% average foreign holding, 120 companies, driven by semiconductor and electronics
-- **Financial Services**: 32.1% average foreign holding, concentrated in major banks
-- **Healthcare**: 28.7% average foreign holding, growing interest in biotech
+### 輸出格式骨架（僅示意結構，不含真實數字）：
 
-**Top Foreign Holdings Insights:**
-1. **TSMC (2330)**: 78% foreign holding, near investment limit, strong fundamentals support
-2. **Hon Hai (2317)**: 65% foreign holding, significant available capacity, EMS leader
-3. **MediaTek (2454)**: 72% foreign holding, chip design focus, attractive valuations
+**外資產業投資分析：**
+- **[產業名稱]**：外資持股比例 [依工具回傳]、公司家數 [依工具回傳]、驅動因素說明
 
-**Investment Recommendations:**
-Based on foreign investment patterns, consider stocks with:
-- Strong foreign interest but available investment capacity
-- Solid fundamentals supporting foreign confidence
-- Industries showing increasing foreign allocation trends
+**外資前 20 大持股洞察：**
+1. **[公司名稱]（[代號]）**：外資持股比例 [依工具回傳]、可投資空間 [依工具回傳]、基本面摘要
+2. ...
 
-### Current Analysis Request:
-Analysis Type: {analysis_type}
-{f"Target Industry: {industry}" if industry else ""}
-{f"Target Stock: {stock_symbol}" if stock_symbol else ""}
+**投資建議：**
+根據「工具實際回傳」的外資投資型態，指出：
+- 外資高度關注但仍有投資空間的個股
+- 基本面支撐外資信心的個股
+- 外資配置比例呈上升趨勢的產業
 
-Please provide comprehensive foreign investment analysis using the appropriate APIs above.
+### 本次分析請求：
+分析類型：{analysis_type}
+{f"目標產業：{industry}" if industry else ""}
+{f"目標股票：{stock_symbol}" if stock_symbol else ""}
+
+請先呼叫上述對應工具取得真實資料，再依實際回傳內容提供完整的外資投資分析。
 """
     return PromptMessage(role="user", content=TextContent(type="text", text=content))

--- a/prompts/investment_screening_prompt.py
+++ b/prompts/investment_screening_prompt.py
@@ -5,151 +5,152 @@ from fastmcp.prompts.prompt import PromptMessage, TextContent
 
 def investment_screening_prompt(screening_criteria: str = "comprehensive", risk_level: str = "moderate") -> PromptMessage:
     """Prompt for investment screening using TWSE OpenAPI endpoints."""
-    content = f"""Investment Screening for Taiwan Stock Market:
+    content = f"""台灣股市投資篩選指引
 
-You are a Taiwan stock market investment screening expert. Use the following TWSE OpenAPI endpoints to screen and recommend investment opportunities based on multiple criteria:
+你是台灣股市投資篩選專家。呼叫下方 TWSE OpenAPI 工具，依多重條件篩選並推薦投資標的。
 
-### Available APIs for Investment Screening:
+⚠️ 重要：以下工具用途與輸出格式僅為使用指引與骨架。任何公司名稱、代號或數字皆只是格式示意，絕非真實資料。實際分析前必須先呼叫對應工具取得當下真實回傳資料；分析內容與結論只能依據工具實際回傳的數據撰寫，不可憑空臆測。若查無資料，應如實說明。
 
-**Valuation & Performance:**
-- `get_stock_valuation_ratios(code)`: P/E ratios, dividend yields, P/B ratios
-- `get_stock_daily_trading(code)`: Price performance and trading volume
-- `get_stock_monthly_trading(code)`: Monthly performance trends
-- `get_company_monthly_revenue(code)`: Revenue growth patterns
+### 投資篩選可用工具：
 
-**Quality Indicators:**
-- `get_company_profile(code)`: Company basic information and industry
-- `get_company_income_statement(code)`: Profitability and growth metrics
-- `get_company_balance_sheet(code)`: Financial strength and stability
-- `get_company_dividend(code)`: Dividend history and consistency
+**估值與績效：**
+- `get_stock_valuation_ratios(code)`：本益比、殖利率、股價淨值比
+- `get_stock_daily_trading(code)`：價格表現與成交量
+- `get_stock_monthly_trading(code)`：月度績效趨勢
+- `get_company_monthly_revenue(code)`：營收成長型態
 
-**Market Validation:**
-- `get_market_index_info(category, count, format)`: Sector performance and market context
-  - Use `category="sector", format="summary"` to identify outperforming industries
-  - Use `category="esg", count=10` for ESG investment universe
-  - Use `category="dividend", format="simple"` for income-focused screening
-- `get_top_foreign_holdings()`: Foreign investor preferences (quality signal)
-- `get_etf_regular_investment_ranking()`: Popular retail investment choices
-- `get_margin_trading_info()`: Institutional vs retail interest
-- `get_foreign_investment_by_industry()`: Sector allocation trends
+**品質指標：**
+- `get_company_profile(code)`：公司基本資料與所屬產業
+- `get_company_income_statement(code)`：獲利能力與成長指標
+- `get_company_balance_sheet(code)`：財務體質穩健度
+- `get_company_dividend(code)`：股利歷史與穩定度
 
-**Risk Assessment:**
-- `get_company_major_news(code)`: Recent corporate developments
-- `get_dividend_rights_schedule(code)`: Upcoming corporate actions
-- `get_warrant_daily_trading(code)`: Speculation activity levels
+**市場驗證：**
+- `get_market_index_info(category, count, format)`：類股表現與市場環境
+  - `category="sector", format="summary"`：找出表現領先的產業
+  - `category="esg", count=10`：ESG 投資範圍
+  - `category="dividend", format="simple"`：股利導向篩選
+- `get_top_foreign_holdings()`：外資偏好（品質訊號）
+- `get_etf_regular_investment_ranking()`：散戶熱門投資選擇
+- `get_margin_trading_info()`：法人 vs 散戶關注度
+- `get_foreign_investment_by_industry()`：產業配置趨勢
 
-### Screening Criteria:
+**風險評估：**
+- `get_company_major_news(code)`：近期公司動態
+- `get_dividend_rights_schedule(code)`：即將發生的公司行動
+- `get_warrant_daily_trading(code)`：投機活動水位
 
-**1. Value Investing (screening_criteria="value"):**
-- Low P/E ratios (<15) with stable earnings
-- High dividend yields (>3%) with sustainable payouts  
-- Low P/B ratios (<1.5) with strong balance sheets
-- Foreign investment validation for quality confirmation
+### 篩選條件類型：
 
-**2. Growth Investing (screening_criteria="growth"):**
-- Consistent revenue growth (>10% annually)
-- Expanding profit margins from income statements
-- Increasing foreign ownership (growth recognition)
-- Popular in ETF regular investment rankings
+**1. 價值投資（screening_criteria="value"）：**
+- 低本益比（<15）且獲利穩定
+- 高殖利率（>3%）且配息可永續
+- 低股價淨值比（<1.5）且財務體質穩健
+- 以外資投資驗證品質
 
-**3. Dividend Focus (screening_criteria="dividend"):**
-- High dividend yields with consistent payment history
-- Strong cash flow from operations
-- Stable or growing dividend trends
-- Foreign investor dividend stock preferences
+**2. 成長投資（screening_criteria="growth"）：**
+- 營收持續成長（年增 >10%）
+- 損益表顯示毛利率擴張
+- 外資持股比例上升（成長認同度）
+- 於定期定額熱門排行中出現
 
-**4. Momentum & Trends (screening_criteria="momentum"):**
-- Strong recent price performance with volume confirmation
-- Positive news flow and corporate developments
-- Increasing foreign investment interest
-- Above-average trading activity
+**3. 股利導向（screening_criteria="dividend"）：**
+- 高殖利率且配息紀錄穩定
+- 營運現金流強勁
+- 股利穩定或持續成長
+- 符合外資對股利股的偏好
 
-**5. Comprehensive Analysis (screening_criteria="comprehensive"):**
-Combine all factors for balanced recommendations:
-- Value metrics within reasonable ranges
-- Growth prospects with quality indicators
-- Dividend sustainability and yield attractiveness
-- Market validation through foreign/institutional interest
+**4. 動能與趨勢（screening_criteria="momentum"）：**
+- 近期價格表現強勁且成交量佐證
+- 新聞與公司動態正向
+- 外資投資關注度上升
+- 交易活躍度高於平均
 
-### Risk Level Adjustments:
+**5. 綜合分析（screening_criteria="comprehensive"）：**
+綜合以上因子提供均衡建議：
+- 估值指標落在合理區間
+- 具品質支撐的成長潛力
+- 配息可永續性與殖利率吸引力
+- 外資／法人關注度驗證市場認同
 
-**Conservative ({risk_level}="conservative"):**
-- Large-cap companies with stable business models
-- Strong balance sheets and consistent dividends
-- High foreign ownership (>30%) as quality indicator
-- Established market leaders in defensive sectors
+### 風險等級調整：
 
-**Moderate ({risk_level}="moderate"):**
-- Mix of large and mid-cap opportunities
-- Growth with reasonable valuations
-- Moderate foreign ownership (15-30%)
-- Balanced risk-return characteristics
+**保守型（risk_level="conservative"）：**
+- 具穩定商業模式的大型股
+- 財務體質穩健、配息穩定
+- 外資持股比例偏高（>30%）作為品質指標
+- 防禦型產業中的市場領導者
 
-**Aggressive ({risk_level}="aggressive"):**
-- Small to mid-cap growth opportunities
-- Higher growth rates with acceptable valuations
-- Emerging trends and market themes
-- Some speculation through warrant activity
+**穩健型（risk_level="moderate"）：**
+- 大型股與中型股機會並重
+- 兼顧成長性與合理估值
+- 外資持股比例中等（15–30%）
+- 風險報酬均衡
 
-### Screening Process:
+**積極型（risk_level="aggressive"）：**
+- 中小型成長股機會
+- 較高成長率且估值可接受
+- 新興趨勢與市場主題
+- 可承受部分權證投機活動
 
-**Step 1: Universe Definition**
-- Use `get_top_foreign_holdings()` and `get_etf_regular_investment_ranking()` for quality universe
-- Filter by market cap and liquidity requirements
-- Consider sector diversification needs
+### 篩選流程：
 
-**Step 2: Quantitative Screening**
-- Apply valuation, growth, and dividend criteria
-- Screen for financial strength metrics
-- Analyze trading patterns and volume trends
+**步驟一：投資範圍界定**
+- 以 `get_top_foreign_holdings()` 與 `get_etf_regular_investment_ranking()` 建立品質投資範圍
+- 依市值與流動性條件篩選
+- 考量產業分散需求
 
-**Step 3: Qualitative Validation**
-- Review recent news and corporate developments
-- Assess foreign investor interest trends
-- Evaluate upcoming corporate actions impact
+**步驟二：量化篩選**
+- 套用估值、成長、股利條件
+- 篩選財務體質指標
+- 分析成交型態與量能趨勢
 
-**Step 4: Risk Assessment**
-- Check margin trading levels for speculation risks
-- Review warrant activity as sentiment indicator
-- Assess sector and market concentration risks
+**步驟三：質化驗證**
+- 檢視近期新聞與公司動態
+- 評估外資關注度趨勢
+- 評估即將發生的公司行動之影響
 
-### Output Format:
+**步驟四：風險評估**
+- 檢視融資水位以評估投機風險
+- 檢視權證活躍度作為情緒指標
+- 評估產業與市場集中度風險
 
-**🎯 Investment Recommendations:**
+### 輸出格式骨架（僅示意結構，不含真實數字）：
 
-**Top Picks:**
-1. **Company (Code)**: Rationale, Key Metrics, Risk Level
-2. **Company (Code)**: Rationale, Key Metrics, Risk Level
-3. **Company (Code)**: Rationale, Key Metrics, Risk Level
+**🎯 投資建議：**
 
-**📊 Screening Results by Criteria:**
-- **Value Stocks**: Best P/E, P/B, dividend yield combinations
-- **Growth Stocks**: Revenue growth, margin expansion, market expansion
-- **Dividend Stocks**: Yield, sustainability, growth potential
-- **Foreign Favorites**: High foreign ownership with strong fundamentals
+**優選標的：**
+1. **[公司名稱]（[代號]）**：選股理由、關鍵指標、風險等級（皆依工具實際回傳資料填寫）
+2. ...
 
-**⚖️ Risk-Return Analysis:**
-- Expected return profiles by risk level
-- Diversification recommendations
-- Sector allocation suggestions
-- Position sizing guidelines
+**📊 依條件分類的篩選結果：**
+- **價值股**：本益比、股價淨值比、殖利率組合最佳者
+- **成長股**：營收成長、毛利擴張、市場擴張表現
+- **股利股**：殖利率、永續性、成長潛力
+- **外資偏好股**：外資持股高且基本面穩健者
 
-**📈 Market Context:**
-- Current market environment assessment
-- Sector rotation trends and opportunities  
-- Foreign investment flow implications
-- Timing considerations for entry
+**⚖️ 風險報酬分析：**
+- 各風險等級的預期報酬輪廓
+- 分散配置建議
+- 產業配置建議
+- 部位大小建議
 
-**🔍 Further Research Recommendations:**
-- Companies requiring deeper fundamental analysis
-- Emerging trends worth monitoring
-- Potential catalysts and risk factors
-- Portfolio construction considerations
+**📈 市場環境：**
+- 當前市場環境評估
+- 類股輪動趨勢與機會
+- 外資流向的意涵
+- 進場時機考量
 
-### Current Screening Request:
-Screening Criteria: {screening_criteria}
-Risk Level: {risk_level}
+**🔍 建議進一步研究：**
+- 需要更深入基本面分析的公司
+- 值得持續觀察的新興趨勢
+- 潛在催化因子與風險因子
+- 投資組合建構考量
 
-Please provide comprehensive investment screening using the appropriate APIs above.
+### 本次篩選請求：
+篩選條件：{screening_criteria}
+風險等級：{risk_level}
+
+請先呼叫上述對應工具取得真實資料，再依實際回傳內容提供完整的投資篩選分析。
 """
     return PromptMessage(role="user", content=TextContent(type="text", text=content))

--- a/prompts/market_hotspot_monitoring_prompt.py
+++ b/prompts/market_hotspot_monitoring_prompt.py
@@ -5,97 +5,99 @@ from fastmcp.prompts.prompt import PromptMessage, TextContent
 
 def market_hotspot_monitoring_prompt(monitoring_scope: str = "comprehensive", date_filter: str = "today") -> PromptMessage:
     """Prompt for market hotspot monitoring using TWSE OpenAPI endpoints."""
-    content = f"""Market Hotspot Monitoring for Taiwan Stock Market:
+    content = f"""台灣股市熱點監控指引
 
-You are a Taiwan stock market monitoring expert. Use the following TWSE OpenAPI endpoints to identify market hotspots, trending stocks, and important market developments:
+你是台灣股市監控專家。呼叫下方 TWSE OpenAPI 工具，找出市場熱點、趨勢股與重要市場動態。
 
-### Available APIs for Hotspot Detection:
+⚠️ 重要：以下工具用途與輸出格式僅為使用指引與骨架。任何公司名稱、事件或數字皆只是格式示意，絕非真實資料。實際分析前必須先呼叫對應工具取得當下真實回傳資料；分析內容與結論只能依據工具實際回傳的數據撰寫，不可憑空臆測。若查無資料，應如實說明。
 
-**News & Announcements:**
-- `get_company_major_news(code)`: Company major announcements (filter by company or get all)
-- `get_twse_news(start_date, end_date)`: Latest TWSE official news and announcements (with optional date filtering)
-- `get_twse_events(top=10)`: TWSE events and activities
+### 熱點偵測可用工具：
 
-**Market Activity Indicators:**
-- `get_real_time_trading_stats()`: Real-time market statistics
-- `get_market_index_info(category, count, format)`: Market indices analysis with flexible filtering
-  - Use `category="major", format="summary"` for quick market overview
-  - Use `category="sector", format="simple"` to identify hot sectors
-  - Use `category="thematic", count=10` for trending themes (AI, 5G, ESG, etc.)
-- `get_stock_daily_trading(code)`: Daily trading volume and price movements
-- `get_etf_regular_investment_ranking()`: Popular ETF investment trends
-- `get_top_foreign_holdings()`: Foreign investment flow indicators
+**新聞與公告：**
+- `get_company_major_news(code)`：公司重大公告（可依公司篩選或取得全部）
+- `get_twse_news(start_date, end_date)`：證交所最新官方新聞（可依日期篩選）
+- `get_twse_events(top=10)`：證交所活動與事件
 
-**Corporate Actions:**
-- `get_dividend_rights_schedule(code)`: Upcoming ex-dividend dates
-- `get_warrant_daily_trading(code)`: Warrant trading activity (speculation indicator)
+**市場活動指標：**
+- `get_real_time_trading_stats()`：即時市場統計
+- `get_market_index_info(category, count, format)`：市場指數分析（可彈性篩選）
+  - `category="major", format="summary"`：快速掌握大盤概況
+  - `category="sector", format="simple"`：找出熱門類股
+  - `category="thematic", count=10`：熱門主題（AI、5G、ESG 等）
+- `get_stock_daily_trading(code)`：個股日成交量與價格變動
+- `get_etf_regular_investment_ranking()`：熱門定期定額投資趨勢
+- `get_top_foreign_holdings()`：外資流向指標
 
-### Monitoring Scopes:
+**公司行動：**
+- `get_dividend_rights_schedule(code)`：即將除權息日期
+- `get_warrant_daily_trading(code)`：權證交易活躍度（投機指標）
 
-**1. Breaking News Monitoring (monitoring_scope="news"):**
-Focus on `get_company_major_news()` and `get_twse_news(start_date, end_date)` to identify:
-- Companies with significant announcements today
-- Regulatory changes or policy updates
-- Market-moving news and corporate actions
-- Industry-specific developments
+### 監控範圍：
 
-**2. Trading Activity Hotspots (monitoring_scope="trading"):**
-Use trading-related APIs to find:
-- Stocks with unusual volume or price movements
-- ETFs gaining popularity in regular investment plans
-- Warrant activity indicating market speculation
-- Foreign investment flow changes
+**1. 即時新聞監控（monitoring_scope="news"）：**
+呼叫 `get_company_major_news()` 與 `get_twse_news(start_date, end_date)`，依實際回傳資料找出：
+- 今日有重大公告的公司
+- 法規變動或政策更新
+- 影響市場的新聞與公司行動
+- 產業別重大動態
 
-**3. Comprehensive Market Scan (monitoring_scope="comprehensive"):**
-Combine all APIs for complete market overview:
-- Major news affecting multiple sectors
-- Trading volume and foreign investment patterns
-- Upcoming corporate actions and their potential impact
-- Overall market sentiment indicators
+**2. 交易活動熱點（monitoring_scope="trading"）：**
+呼叫交易相關工具，依實際回傳資料找出：
+- 成交量或價格異常波動的個股
+- 定期定額熱門度上升的 ETF
+- 反映市場投機氣氛的權證活動
+- 外資投資流向變化
 
-### Analysis Framework:
+**3. 全面市場掃描（monitoring_scope="comprehensive"）：**
+綜合呼叫上述工具，依實際回傳資料提供：
+- 影響多個產業的重大新聞
+- 成交量與外資流向型態
+- 即將發生的公司行動及其潛在影響
+- 整體市場情緒指標
 
-**Step 1: News Impact Assessment**
-- Scan major announcements for market-moving potential
-- Identify companies with multiple recent announcements
-- Assess regulatory or policy impact on sectors
+### 分析流程：
 
-**Step 2: Trading Pattern Analysis**
-- Compare current trading volumes with historical averages
-- Identify foreign investment flow changes
-- Monitor ETF and warrant activity for sentiment
+**步驟一：新聞影響評估**
+- 依實際回傳的公告內容，篩選具市場影響力者
+- 找出近期多次發布公告的公司
+- 評估法規或政策對產業的影響
 
-**Step 3: Forward-Looking Indicators**
-- Upcoming ex-dividend dates affecting stock prices
-- Corporate events that may drive future trading
-- TWSE events that may impact market structure
+**步驟二：交易型態分析**
+- 依實際回傳資料比對成交量與歷史水位
+- 找出外資流向的變化
+- 觀察 ETF 與權證活躍度反映的情緒
 
-### Output Format:
+**步驟三：前瞻指標**
+- 影響未來股價的即將除權息日期
+- 可能帶動未來交易的公司行動
+- 可能影響市場結構的證交所事件
 
-**Market Hotspots Summary:**
-🔥 **Top Hotspots Today:**
-1. **Company/Sector**: Reason for attention, relevant news, trading impact
-2. **Market Theme**: Description, affected stocks, trend analysis
+### 輸出格式骨架（僅示意結構，不含真實數字）：
 
-📈 **Trading Activity Alerts:**
-- High volume stocks with supporting news
-- Foreign investment flow changes
-- Popular investment trends (ETF rankings)
+**市場熱點總覽：**
+🔥 **今日焦點（依工具實際回傳資料填寫）：**
+1. **[公司/產業]**：關注原因、相關新聞、交易面影響
+2. ...
 
-📅 **Upcoming Events:**
-- Ex-dividend dates in next 5 trading days
-- Important TWSE announcements or events
-- Corporate actions to watch
+📈 **交易活動警示：**
+- 依實際回傳資料列出高量個股與對應新聞
+- 外資流向變化
+- 熱門投資趨勢（ETF 排行）
 
-🎯 **Investment Implications:**
-- Short-term trading opportunities
-- Medium-term trend shifts
-- Risk factors to monitor
+📅 **未來事件：**
+- 未來 5 個交易日內的除權息日期（依工具實際回傳）
+- 重要證交所公告或事件
+- 待觀察的公司行動
 
-### Current Monitoring Request:
-Monitoring Scope: {monitoring_scope}
-Date Filter: {date_filter}
+🎯 **投資意涵：**
+- 短期交易機會
+- 中期趨勢轉變
+- 需留意的風險因子
 
-Please provide comprehensive market hotspot analysis using the appropriate APIs above.
+### 本次監控請求：
+監控範圍：{monitoring_scope}
+日期篩選：{date_filter}
+
+請先呼叫上述對應工具取得真實資料，再依實際回傳內容提供完整的市場熱點分析。
 """
     return PromptMessage(role="user", content=TextContent(type="text", text=content))

--- a/prompts/twse_stock_trend_prompt.py
+++ b/prompts/twse_stock_trend_prompt.py
@@ -2,61 +2,63 @@ from fastmcp.prompts.prompt import PromptMessage, TextContent
 
 def twse_stock_trend_prompt(stock_symbol: str, period: str) -> PromptMessage:
     """Prompt for Taiwan Stock Trend Analysis using TWSE OpenAPI endpoints."""
-    content = f"""Prompt for Taiwan Stock Trend Analysis using TWSE OpenAPI endpoints:
+    content = f"""台灣股市趨勢分析指引
 
-You are a Taiwan stock market trend analysis expert. Based on the user's input stock symbol and analysis period (short/medium/long-term), automatically select and utilize the following comprehensive TWSE MCP tools to perform multi-perspective analysis (technical, fundamental, chip, market sentiment, and news). Clearly present your reasoning and conclusion in bullet-point format:
+你是台灣股市趨勢分析專家。根據使用者提供的股票代號與分析週期（短/中/長期），依下方對照表選用對應的 TWSE MCP 工具，從技術面、基本面、籌碼面、市場情緒與消息面進行多角度分析，並以條列方式清楚呈現推理過程與結論。
 
-### Available MCP Tools by Analysis Timeframe:
+⚠️ 重要：以下工具對照與輸出格式僅為使用指引與骨架，範本中若出現任何具體數字、走勢描述或多空結論，皆只是格式示意，絕非真實市場資料。實際分析前，必須先呼叫對應工具取得當下真實回傳資料；分析內容與結論只能依據工具實際回傳的數據撰寫，不可憑空臆測、外插或沿用範本中的示意文字。若工具回傳資料不足或查無資料，應如實說明，不可捏造。
 
-- **Short-Term Analysis (1-30 days):**
-  - **Technical**: `get_stock_daily_trading(code)` - Daily prices, volumes, and trading statistics
-  - **Technical**: `get_real_time_trading_stats()` - Real-time market statistics (5-second updates)
-  - **Chip**: `get_margin_trading_info()` - Margin trading and short selling data
-  - **Chip**: `get_foreign_investment_by_industry()` - Foreign investment flows by industry
-  - **Market Sentiment**: `get_warrant_daily_trading(code)` - Warrant trading activity (leverage indicator)
-  - **News**: `get_company_major_news(code)` - Recent major announcements
+### 依分析週期對應的可用工具：
 
-- **Medium-Term Analysis (1-12 months):**
-  - **Technical**: `get_stock_monthly_average(code)` - Monthly average prices and volumes
-  - **Technical**: `get_stock_monthly_trading(code)` - Monthly trading statistics
-  - **Fundamental**: `get_company_monthly_revenue(code)` - Monthly revenue trends
-  - **Fundamental**: `get_company_income_statement(code)` - Quarterly income statements
-  - **Fundamental**: `get_company_balance_sheet(code)` - Balance sheet data
-  - **Chip**: `get_top_foreign_holdings()` - Foreign investment concentration in top stocks
-  - **Events**: `get_dividend_rights_schedule(code)` - Upcoming ex-dividend dates
+- **短期分析（1–30 天）：**
+  - **技術面**：`get_stock_daily_trading(code)` — 個股日成交價量與統計資料
+  - **技術面**：`get_real_time_trading_stats()` — 即時市場統計（每5秒更新）
+  - **籌碼面**：`get_margin_trading_info()` — 融資融券資料
+  - **籌碼面**：`get_foreign_investment_by_industry()` — 各產業外資持股流向
+  - **市場情緒**：`get_warrant_daily_trading(code)` — 權證交易活躍度（槓桿指標）
+  - **消息面**：`get_company_major_news(code)` — 近期重大公告
 
-- **Long-Term Analysis (1+ years):**
-  - **Technical**: `get_stock_yearly_trading(code)` - Annual trading patterns
-  - **Valuation**: `get_stock_valuation_ratios(code)` - P/E, dividend yield, P/B ratios
-  - **Fundamental**: `get_company_dividend(code)` - Dividend history and policy
-  - **ESG**: `get_company_governance_info(code)` - Corporate governance quality
-  - **Market Context**: `get_market_historical_index()` - Historical market performance
+- **中期分析（1–12 個月）：**
+  - **技術面**：`get_stock_monthly_average(code)` — 月均價與月成交量
+  - **技術面**：`get_stock_monthly_trading(code)` — 月成交統計
+  - **基本面**：`get_company_monthly_revenue(code)` — 月營收趨勢
+  - **基本面**：`get_company_income_statement(code)` — 季度損益表
+  - **基本面**：`get_company_balance_sheet(code)` — 資產負債表
+  - **籌碼面**：`get_top_foreign_holdings()` — 外資集中持股個股
+  - **事件面**：`get_dividend_rights_schedule(code)` — 即將除權息日期
 
-### Example Input:
-Please analyze the {period} trend of {stock_symbol}.
+- **長期分析（1 年以上）：**
+  - **技術面**：`get_stock_yearly_trading(code)` — 年度交易統計
+  - **估值面**：`get_stock_valuation_ratios(code)` — 本益比、殖利率、股價淨值比
+  - **基本面**：`get_company_dividend(code)` — 股利發放歷史與政策
+  - **ESG**：`get_company_governance_info(code)` — 公司治理品質
+  - **市場環境**：`get_market_historical_index()` — 大盤歷史表現
 
-### Example Output:
+### 範例輸入：
+請分析 {stock_symbol} 的{period}走勢。
 
-**Short-Term Analysis:**
-1. **Technical**: Using `get_stock_daily_trading({stock_symbol})`, the stock price has risen above its 20-day moving average with increasing volume. `get_real_time_trading_stats()` confirms strong intraday momentum.
-2. **Chip**: `get_margin_trading_info()` shows decreasing margin balances and increasing short covering, indicating bullish sentiment. `get_foreign_investment_by_industry()` reveals net foreign buying in the sector.
-3. **Market Sentiment**: `get_warrant_daily_trading({stock_symbol})` shows increased call warrant activity, suggesting bullish leverage positioning.
-4. **News**: `get_company_major_news({stock_symbol})` shows positive announcements supporting the uptrend.
+### 分析流程（非結論範本，僅示意步驟）：
 
-**Medium-Term Analysis:**
-1. **Technical**: `get_stock_monthly_average({stock_symbol})` and `get_stock_monthly_trading({stock_symbol})` show consistent upward trend with healthy volume patterns.
-2. **Fundamental**: `get_company_monthly_revenue({stock_symbol})` reveals sustained growth. `get_company_income_statement({stock_symbol})` and `get_company_balance_sheet({stock_symbol})` confirm improving profitability and financial health.
-3. **Chip**: `get_top_foreign_holdings()` indicates the stock is gaining foreign institutional interest.
-4. **Events**: `get_dividend_rights_schedule({stock_symbol})` shows upcoming ex-dividend date that may support price.
+**短期分析：**
+1. 呼叫 `get_stock_daily_trading({stock_symbol})` 與 `get_real_time_trading_stats()`，依實際回傳的股價、成交量數據描述短期價量狀況。
+2. 呼叫 `get_margin_trading_info()` 與 `get_foreign_investment_by_industry()`，依實際回傳數據描述融資融券與外資流向。
+3. 呼叫 `get_warrant_daily_trading({stock_symbol})`，依實際數據描述權證活躍度所反映的市場情緒。
+4. 呼叫 `get_company_major_news({stock_symbol})`，摘要近期實際公告內容。
 
-**Long-Term Analysis:**
-1. **Technical**: `get_stock_yearly_trading({stock_symbol})` shows multi-year uptrend with strong fundamentals support.
-2. **Valuation**: `get_stock_valuation_ratios({stock_symbol})` indicates attractive P/E ratio, sustainable dividend yield, and reasonable P/B ratio.
-3. **Fundamental**: `get_company_dividend({stock_symbol})` shows consistent dividend growth policy.
-4. **ESG**: `get_company_governance_info({stock_symbol})` indicates strong corporate governance supporting long-term value.
-5. **Market Context**: `get_market_historical_index()` shows the overall market environment remains supportive.
+**中期分析：**
+1. 呼叫 `get_stock_monthly_average({stock_symbol})` 與 `get_stock_monthly_trading({stock_symbol})`，依實際數據描述中期價量趨勢。
+2. 呼叫 `get_company_monthly_revenue({stock_symbol})`、`get_company_income_statement({stock_symbol})`、`get_company_balance_sheet({stock_symbol})`，依實際數據評估營收成長與財務體質。
+3. 呼叫 `get_top_foreign_holdings()`，確認該股是否列於外資集中持股名單。
+4. 呼叫 `get_dividend_rights_schedule({stock_symbol})`，說明即將到來的除權息事件。
 
-### Conclusion:
-The {period} trend for {stock_symbol} is **bullish/bearish** based on the analysis above.
+**長期分析：**
+1. 呼叫 `get_stock_yearly_trading({stock_symbol})`，依實際數據描述多年走勢。
+2. 呼叫 `get_stock_valuation_ratios({stock_symbol})`，依實際本益比、殖利率、股價淨值比評估估值水位。
+3. 呼叫 `get_company_dividend({stock_symbol})`，依實際股利歷史評估配息政策穩定性。
+4. 呼叫 `get_company_governance_info({stock_symbol})`，評估公司治理品質。
+5. 呼叫 `get_market_historical_index()`，說明大盤環境對個股的影響。
+
+### 結論：
+綜合以上「工具實際回傳的資料」給出 {stock_symbol} 在{period}角度的判斷（偏多／偏空／中性皆可，也可能因資料不足而無法下明確結論），並列出支持該判斷的具體數據來源。禁止在未實際呼叫工具、未取得真實數據的情況下直接給出結論。
 """
     return PromptMessage(role="user", content=TextContent(type="text", text=content))


### PR DESCRIPTION
## Summary
- All 5 prompt templates in `prompts/` were English-only despite every underlying tool returning Chinese field names/data and the audience being Taiwanese retail investors.
- Each template mixed legitimate tool-usage guidance with an "Example Output" section containing **concrete invented numbers presented as if real**, e.g.:
  - `foreign_investment_analysis_prompt.py`: hardcoded `**TSMC (2330)**: 78% foreign holding, near investment limit`
  - `twse_stock_trend_prompt.py`: a worked example asserting "the stock price has risen above its 20-day moving average" and concluding "bullish" — a figure that was never computed, in a prompt whose entire purpose is to make the model call tools and compute it.
  - An LLM following the prompt literally could parrot these fabricated figures instead of calling the tools and reasoning over live data — the exact failure mode this MCP server exists to prevent.
- Also, `twse_stock_trend_prompt`'s output section hard-required a binary bullish/bearish verdict, which incentivizes forcing a conclusion even when the data doesn't support one.

## Changes
Rewrote all 5 prompts (`twse_stock_trend_prompt`, `foreign_investment_analysis_prompt`, `dividend_investment_strategy_prompt`, `market_hotspot_monitoring_prompt`, `investment_screening_prompt`) in Traditional Chinese:
- Added an explicit directive up front: example numbers/conclusions in the template are format placeholders only, not real data — tools must be called first and analysis must be based only on their actual return values.
- Replaced invented figures in "example output" sections with bracketed placeholders (`[依工具回傳]` / `[代號]`).
- Relaxed the forced bullish/bearish conclusion to allow neutral or insufficient-data outcomes.
- Tool names/function signatures referenced in the prompts are unchanged.

## Test plan
- [x] `python -m py_compile prompts/*.py`
- [x] Imported and rendered all 5 prompt functions with representative args — all return non-empty `PromptMessage` content, no runtime errors