### PR TITLE
feat: add 4 new prompt templates (TAIFEX, institutional flow, fundamentals, risk scan)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,7 +54,7 @@ tools/
 └── taifex/                   # TAIFEX derivatives: futures_position, put_call_ratio, institutional_general,
                               #   institutional_details, daily_market_report, large_traders_oi,
                               #   options_analytics, margin, trading_statistics
-prompts/                      # 5 prompt templates registered in server.py
+prompts/                      # 9 prompt templates registered in server.py
 ```
 
 ### Key Architectural Patterns

--- a/prompts/company_fundamental_healthcheck_prompt.py
+++ b/prompts/company_fundamental_healthcheck_prompt.py
@@ -1,0 +1,93 @@
+"""Prompt for a company fundamental (financial statement) health check."""
+
+from fastmcp.prompts.prompt import PromptMessage, TextContent
+
+
+def company_fundamental_healthcheck_prompt(stock_symbol: str, depth: str = "standard") -> PromptMessage:
+    """Prompt for a comprehensive fundamental/financial-statement health check on a company."""
+    content = f"""個股基本面財報體檢指引
+
+你是台灣股市財務報表分析專家。針對指定股票代號，呼叫下方工具，從獲利能力、成長性、財務結構、配息政策、公司治理五個面向進行基本面體檢。
+
+⚠️ 重要：以下工具用途與輸出格式僅為使用指引與骨架。任何財務數字、比率或評語皆只是格式示意，絕非真實資料。實際分析前必須先呼叫對應工具取得當下真實回傳資料；分析內容與結論只能依據工具實際回傳的數據撰寫，不可憑空臆測。若查無資料，應如實說明。禁止給出未經真實數據支持的評分或分數。
+
+### 可用工具與用途（皆以股票代號 code 查詢單一公司）：
+
+**公司基本資料：**
+- `get_company_profile(code)`：公司基本資料與產業分類
+
+**成長性：**
+- `get_company_monthly_revenue(code)`：月營收彙總表
+- `get_company_eps_statistics(code)`：各產業 EPS 統計資訊
+
+**獲利能力：**
+- `get_company_income_statement(code)`：損益表
+- `get_company_profitability_analysis(code)`：財務比率分析（毛利率、營益率、ROE 等）
+
+**財務結構：**
+- `get_company_balance_sheet(code)`：資產負債表
+
+**配息政策：**
+- `get_company_dividend(code)`：股利分派情形
+
+**公司治理：**
+- `get_company_governance_info(code)`：公司治理評鑑相關資訊
+
+**進階（depth="deep" 時使用）：**
+- `get_company_quarterly_earnings_forecast_achievement(code)`：季度財測達成率
+- `get_company_quarterly_audit_variance(code)`：季度查核前後差異數
+
+### 體檢深度：
+
+**快速體檢（depth="quick"）：**
+呼叫 `get_company_profile`、`get_company_monthly_revenue`、`get_company_eps_statistics`、`get_company_dividend`，依實際回傳資料快速掌握公司概況、營收動能與配息。
+
+**標準體檢（depth="standard"）：**
+在快速體檢基礎上，加呼叫 `get_company_income_statement`、`get_company_balance_sheet`、`get_company_profitability_analysis`、`get_company_governance_info`，完整涵蓋五大面向。
+
+**深度體檢（depth="deep"）：**
+在標準體檢基礎上，加呼叫 `get_company_quarterly_earnings_forecast_achievement` 與 `get_company_quarterly_audit_variance`，檢視財測達成狀況與查核調整幅度是否有異常。
+
+### 分析流程：
+
+**步驟一：基本輪廓**
+- 呼叫 `get_company_profile({stock_symbol})`，確認產業別與公司背景
+
+**步驟二：五大面向逐一檢視**
+- 依實際回傳資料，分別針對獲利能力、成長性、財務結構、配息政策、公司治理提出觀察
+- 每個面向的判讀必須引用工具實際回傳的具體數字，不可泛泛而談
+
+**步驟三：交叉比對**
+- 營收趨勢（`get_company_monthly_revenue`）是否與損益表獲利趨勢一致
+- 配息（`get_company_dividend`）是否與獲利能力、財務結構匹配（例如高配息但財務結構轉弱應提出警示）
+
+### 輸出格式骨架（僅示意結構，不含真實數字）：
+
+**🏢 公司概況：**
+[依 get_company_profile 實際回傳資料摘要]
+
+**💰 獲利能力：**
+[依實際回傳的損益表與財務比率數據描述]
+
+**📈 成長性：**
+[依實際回傳的月營收與 EPS 數據描述趨勢]
+
+**🏦 財務結構：**
+[依實際回傳的資產負債表數據描述體質]
+
+**💵 配息政策：**
+[依實際回傳的股利資料描述配息穩定度與殖利率]
+
+**⚖️ 公司治理：**
+[依實際回傳的治理評鑑資料描述]
+
+**📝 綜合評語：**
+綜合以上「工具實際回傳」的五大面向資料，提出整體體質評語（不得給出未經數據支持的量化分數），並指出資料不足、需進一步查證的部分。
+
+### 本次體檢請求：
+股票代號：{stock_symbol}
+體檢深度：{depth}
+
+請先呼叫上述對應工具取得真實資料，再依實際回傳內容提供完整的基本面財報體檢。
+"""
+    return PromptMessage(role="user", content=TextContent(type="text", text=content))

--- a/prompts/institutional_flow_prompt.py
+++ b/prompts/institutional_flow_prompt.py
@@ -1,0 +1,79 @@
+"""Prompt for three-major-institutional-investors (三大法人) flow analysis."""
+
+from fastmcp.prompts.prompt import PromptMessage, TextContent
+
+
+def institutional_flow_prompt(target: str = "market", stock_symbol: str = "") -> PromptMessage:
+    """Prompt for institutional investor (foreign/investment trust/dealer) flow analysis."""
+    content = f"""三大法人籌碼流向分析指引
+
+你是台灣股市三大法人（外資、投信、自營商）籌碼分析專家。呼叫下方工具，分析法人買賣超動向。
+
+⚠️ 重要：以下工具用途與輸出格式僅為使用指引與骨架。任何買賣超股數、比例或個股名稱皆只是格式示意，絕非真實資料。實際分析前必須先呼叫對應工具取得當下真實回傳資料；分析內容與結論只能依據工具實際回傳的數據撰寫，不可憑空臆測。若查無資料，應如實說明。
+
+### 可用工具與用途：
+
+**上市大盤/個股買賣超：**
+- `get_twse_institutional_investors_summary(date, limit=50, offset=0)`：指定日期全上市股票三大法人買賣超日報，date 格式 YYYYMMDD（西元，需為交易日）
+- `get_twse_institutional_investors_by_stock(stock_no, date)`：指定個股在指定日期的三大法人買賣超明細（外資、投信、自營商各別及合計）
+
+**外資持股結構：**
+- `get_top_foreign_holdings()`：外資持股前 20 大公司
+- `get_foreign_investment_by_industry()`：各產業外資持股比例
+
+**上櫃三大法人：**
+- `get_otc_institutional(stock_no="", limit=50, offset=0)`：上櫃三大法人買賣超，stock_no 留空查全部
+- `get_otc_institutional_summary()`：上櫃三大法人買賣超總表
+
+**期貨法人連動（輔助判斷現貨期貨是否同向）：**
+- `get_futures_institutional()`：三大法人期貨交易與未平倉部位
+
+### 分析目標：
+
+**1. 大盤整體（target="market"）：**
+呼叫 `get_twse_institutional_investors_summary(date)`，依實際回傳資料找出買超/賣超前幾大個股，並觀察外資、投信、自營商是否同向。
+
+**2. 個股籌碼（target="stock"，需提供 stock_symbol）：**
+呼叫 `get_twse_institutional_investors_by_stock(stock_symbol, date)`，依實際回傳資料分析該股近期法人買賣超趨勢；可搭配 `get_top_foreign_holdings()` 確認是否列入外資集中持股。
+
+**3. 外資產業配置（target="foreign_focus"）：**
+呼叫 `get_top_foreign_holdings()` 與 `get_foreign_investment_by_industry()`，依實際回傳資料分析外資的產業偏好與集中度變化。
+
+**4. 上櫃市場（target="otc"）：**
+呼叫 `get_otc_institutional_summary()` 與 `get_otc_institutional(stock_no)`，依實際回傳資料分析上櫃三大法人動向。
+
+### 分析流程：
+
+**步驟一：取得法人買賣超資料**
+- 依 target 呼叫對應工具，取得指定日期或個股的真實回傳資料
+
+**步驟二：判讀法人態度**
+- 比對外資、投信、自營商買賣超方向是否一致（同向代表訊號較強，分歧則需謹慎解讀）
+- 個股分析需同時檢視近期連續趨勢，而非單日數據
+
+**步驟三：交叉驗證**
+- 個股分析可搭配 `get_futures_institutional()`，觀察現貨與期貨法人部位是否同向
+- 外資分析可搭配 `get_foreign_investment_by_industry()` 確認是否符合產業配置趨勢
+
+### 輸出格式骨架（僅示意結構，不含真實數字）：
+
+**📊 法人買賣超總覽：**
+- 外資：[依工具回傳]股 | 投信：[依工具回傳]股 | 自營商：[依工具回傳]股
+
+**🏆 買超/賣超焦點（依工具實際回傳資料填寫）：**
+1. **[公司名稱]（[代號]）**：買賣超股數、法人動向解讀
+2. ...
+
+**🌏 外資產業配置：**
+- 依 `get_foreign_investment_by_industry()` 實際回傳資料，列出外資持股比例較高的產業
+
+**🎯 綜合研判：**
+- 依「工具實際回傳」的法人買賣超數據，給出對後續動向的判斷（可為多方主導／空方主導／法人分歧／資料不足），並列出支持該判斷的具體數據來源。
+
+### 本次分析請求：
+分析目標：{target}
+{f"目標股票：{stock_symbol}" if stock_symbol else ""}
+
+請先呼叫上述對應工具取得真實資料，再依實際回傳內容提供完整的三大法人籌碼流向分析。
+"""
+    return PromptMessage(role="user", content=TextContent(type="text", text=content))

--- a/prompts/pre_trade_risk_scan_prompt.py
+++ b/prompts/pre_trade_risk_scan_prompt.py
@@ -1,0 +1,75 @@
+"""Prompt for a pre-trade risk scan (disposal/warning/day-trading-restriction stocks)."""
+
+from fastmcp.prompts.prompt import PromptMessage, TextContent
+
+
+def pre_trade_risk_scan_prompt(market: str = "twse", stock_symbol: str = "") -> PromptMessage:
+    """Prompt for scanning disposal/warning/restriction lists before placing a trade."""
+    content = f"""買前風險掃描指引
+
+你是台灣股市交易風險審查專家。買進一檔股票前，呼叫下方工具，檢查該股是否命中處置股、注意股、變更交易、當沖限制、停資停券等風險名單。
+
+⚠️ 重要：以下工具用途與輸出格式僅為使用指引與骨架。任何個股名稱或命中結果皆只是格式示意，絕非真實資料。實際分析前必須先呼叫對應工具取得當下真實回傳資料；分析內容與結論只能依據工具實際回傳的數據撰寫，不可憑空臆測。若查無資料，應如實說明「未命中」而非省略。
+
+### 可用工具與用途：
+
+**上市（TWSE）風險名單 — 皆以 name（公司名稱關鍵字）篩選，留空回傳全部：**
+- `get_market_disposal_stocks(name="", limit=50, offset=0)`：集中市場公布處置股票
+- `get_today_notice_stocks(name="", limit=50, offset=0)`：當日注意股票
+- `get_abnormal_accumulated_notice_stocks(name="", limit=50, offset=0)`：累積注意股票
+- `get_securities_trading_changes(name="", limit=50, offset=0)`：證券變更交易
+- `get_daily_day_trading_targets(name="", limit=50, offset=0)`：每日當沖交易標的及統計
+- `get_suspended_day_trading_announcement(name="", limit=50, offset=0)`：暫停先賣後買當沖交易標的預告
+- `get_margin_loan_restrictions_announcement(name="", limit=50, offset=0)`：停資停券預告表
+- `get_financial_program_abnormal_recommendations(name="", limit=50, offset=0)`：投資理財節目異常推介個股
+
+**上櫃（OTC）風險名單 — 皆以 stock_no（股票代號）篩選，留空回傳全部：**
+- `get_otc_warning_stocks(stock_no="")`：上櫃注意股票
+- `get_otc_disposal_stocks(stock_no="")`：上櫃處置股票
+
+### 掃描範圍：
+
+**上市（market="twse"）：**
+呼叫全部上市風險名單工具。若提供 stock_symbol，需先取得該股「公司名稱」（可用 `get_company_profile(stock_symbol)` 查得），再以名稱關鍵字比對各工具的實際回傳資料中是否出現。
+
+**上櫃（market="otc"）：**
+呼叫 `get_otc_warning_stocks(stock_symbol)` 與 `get_otc_disposal_stocks(stock_symbol)`，直接以股票代號查詢。
+
+**兩者皆查（market="both"）：**
+同時執行上市與上櫃掃描流程。
+
+### 分析流程：
+
+**步驟一：確認查詢對象**
+- 若提供 stock_symbol，先確認其市場別（上市／上櫃）；不確定時可兩者皆查
+
+**步驟二：逐一呼叫風險名單工具**
+- 依 market 呼叫對應工具集合，取得實際回傳資料
+- 若提供 stock_symbol，逐一比對該股是否出現在各工具的回傳結果中
+
+**步驟三：彙整命中結果**
+- 只能依「工具實際回傳」中確實出現的項目標記為命中，未查到則明確標記「未命中」
+- 不可將「未呼叫該工具」與「查無資料」混淆
+
+### 輸出格式骨架（僅示意結構，不含真實數字）：
+
+**🚨 風險命中清單（依工具實際回傳資料填寫）：**
+- 處置股：[命中／未命中，依實際回傳]
+- 注意股：[命中／未命中，依實際回傳]
+- 變更交易：[命中／未命中，依實際回傳]
+- 當沖限制：[命中／未命中，依實際回傳]
+- 停資停券：[命中／未命中，依實際回傳]
+
+**📖 命中項目說明：**
+針對每個命中的旗標，簡要說明該名單代表的意義與交易限制（例如處置股可能有分盤交易、高保證金等限制）。
+
+**⚖️ 綜合風險評級：**
+依「實際命中的旗標數量與嚴重程度」給出風險等級（高／中／低／無異常），並列出判斷依據。禁止在未實際查詢的情況下預設風險等級。
+
+### 本次掃描請求：
+市場範圍：{market}
+{f"目標股票：{stock_symbol}" if stock_symbol else "（未指定個股，將列出各風險名單概況）"}
+
+請先呼叫上述對應工具取得真實資料，再依實際回傳內容提供完整的買前風險掃描結果。
+"""
+    return PromptMessage(role="user", content=TextContent(type="text", text=content))

--- a/prompts/taifex_derivatives_prompt.py
+++ b/prompts/taifex_derivatives_prompt.py
@@ -1,0 +1,82 @@
+"""Prompt for TAIFEX futures/options derivatives analysis."""
+
+from fastmcp.prompts.prompt import PromptMessage, TextContent
+
+
+def taifex_derivatives_prompt(scope: str = "comprehensive") -> PromptMessage:
+    """Prompt for TAIFEX futures/options chip analysis using TAIFEX OpenAPI endpoints."""
+    content = f"""台灣期貨選擇權籌碼分析指引
+
+你是台灣期貨市場（TAIFEX）籌碼分析專家。呼叫下方 TAIFEX OpenAPI 工具，分析期貨與選擇權市場的多空氛圍、主力籌碼與法人部位。
+
+⚠️ 重要：以下工具用途與輸出格式僅為使用指引與骨架。任何比率、口數或結論皆只是格式示意，絕非真實資料。實際分析前必須先呼叫對應工具取得當下真實回傳資料；分析內容與結論只能依據工具實際回傳的數據撰寫，不可憑空臆測。若查無資料，應如實說明。
+
+### 可用工具與用途：
+
+**多空氛圍：**
+- `get_put_call_ratio()`：選擇權 Put/Call Ratio，反映市場整體多空情緒
+
+**主力籌碼（大額交易人）：**
+- `get_large_traders_futures_oi(contract="TX")`：期貨大額交易人未沖銷部位（contract 預設臺股期貨 TX，可查其他契約）
+- `get_large_traders_options_oi(contract="TXO", call_put="")`：選擇權大額交易人未沖銷部位，call_put 可篩選「買權」或「賣權」
+
+**三大法人期貨/選擇權部位：**
+- `get_futures_institutional()`：三大法人期貨交易與未平倉
+- `get_institutional_general()`：三大法人期貨+選擇權整體合計（交易量、金額、未平倉、契約價值）
+- `get_institutional_traders_by_futures(contract_code="")`：三大法人各期貨契約明細，contract_code 留空列出全部
+- `get_institutional_traders_by_options(contract_code="")`：三大法人各選擇權契約明細
+- `get_institutional_traders_calls_puts(contract_code="", call_put="")`：三大法人選擇權 CALL/PUT 分計，觀察外資對後市看法的關鍵指標
+
+**選擇權結構：**
+- `get_options_delta(contract="TXO", contract_month="", call_put="")`：各履約價 Delta 值，資料量大時建議指定 contract_month（如「202605」）
+- `get_options_oi_change()`：選擇權未平倉增減，可推算潛在支撐壓力區
+
+**每日行情：**
+- `get_daily_futures_market_report(contract="TX")`：期貨每日行情
+- `get_daily_options_market_report(contract="TXO", call_put="", limit=30)`：選擇權每日行情（依成交量排序）
+
+**保證金：**
+- `get_index_futures_margin(contract="")`：指數期貨保證金
+- `get_stock_futures_margin(stock_code="")`：股票期貨保證金
+
+**統計：**
+- `get_annual_trading_volume(contract="")`：年度交易量統計
+- `get_monthly_trading_statistics()`：月度交易統計
+
+### 分析範圍：
+
+**1. 市場情緒（scope="sentiment"）：**
+呼叫 `get_put_call_ratio()` 與 `get_institutional_traders_calls_puts()`，依實際回傳資料判斷市場多空氣氛與法人 CALL/PUT 布局傾向。
+
+**2. 主力部位（scope="positioning"）：**
+呼叫 `get_large_traders_futures_oi()`、`get_large_traders_options_oi()`、`get_futures_institutional()`、`get_institutional_general()`，依實際回傳資料分析主力與三大法人的多空部位變化。
+
+**3. 選擇權結構（scope="options_structure"）：**
+呼叫 `get_options_delta()` 與 `get_options_oi_change()`，依實際回傳資料推估各履約價的未平倉分佈，藉此判斷潛在支撐壓力區。
+
+**4. 全面分析（scope="comprehensive"）：**
+綜合呼叫上述所有分組工具，依實際回傳資料提供完整籌碼分析。
+
+### 輸出格式骨架（僅示意結構，不含真實數字）：
+
+**📊 市場多空氛圍：**
+- Put/Call Ratio：[依工具回傳]，情緒判讀：[依實際數值]
+
+**🐋 主力與法人部位：**
+- 大額交易人淨部位：[依工具回傳]
+- 三大法人期貨/選擇權淨部位：[依工具回傳]
+- 外資 CALL/PUT 布局：[依工具回傳]
+
+**🎯 選擇權結構分析：**
+- 未平倉集中的履約價（潛在壓力/支撐）：[依工具回傳]
+- Delta 分佈觀察：[依工具回傳]
+
+**📈 綜合研判：**
+- 依「工具實際回傳」的多空氛圍、部位與結構數據，給出綜合判斷（偏多／偏空／中性皆可，資料不足時應如實說明），並列出支持該判斷的具體數據來源。
+
+### 本次分析請求：
+分析範圍：{scope}
+
+請先呼叫上述對應工具取得真實資料，再依實際回傳內容提供完整的期貨選擇權籌碼分析。
+"""
+    return PromptMessage(role="user", content=TextContent(type="text", text=content))

--- a/server.py
+++ b/server.py
@@ -9,6 +9,10 @@ from prompts.foreign_investment_analysis_prompt import foreign_investment_analys
 from prompts.market_hotspot_monitoring_prompt import market_hotspot_monitoring_prompt
 from prompts.dividend_investment_strategy_prompt import dividend_investment_strategy_prompt
 from prompts.investment_screening_prompt import investment_screening_prompt
+from prompts.taifex_derivatives_prompt import taifex_derivatives_prompt
+from prompts.institutional_flow_prompt import institutional_flow_prompt
+from prompts.company_fundamental_healthcheck_prompt import company_fundamental_healthcheck_prompt
+from prompts.pre_trade_risk_scan_prompt import pre_trade_risk_scan_prompt
 from tools import register_all_tools
 from utils.api_client import TWSEAPIClient
 
@@ -48,6 +52,26 @@ def dividend_investment_strategy(strategy_type: str = "high_yield", time_horizon
 def investment_screening(screening_criteria: str = "comprehensive", risk_level: str = "moderate") -> PromptMessage:
     """Prompt for investment screening using TWSE OpenAPI endpoints."""
     return investment_screening_prompt(screening_criteria, risk_level)
+
+@mcp.prompt
+def taifex_derivatives(scope: str = "comprehensive") -> PromptMessage:
+    """Prompt for TAIFEX futures/options chip analysis using TAIFEX OpenAPI endpoints."""
+    return taifex_derivatives_prompt(scope)
+
+@mcp.prompt
+def institutional_flow(target: str = "market", stock_symbol: str = "") -> PromptMessage:
+    """Prompt for three-major-institutional-investors (foreign/investment trust/dealer) flow analysis."""
+    return institutional_flow_prompt(target, stock_symbol)
+
+@mcp.prompt
+def company_fundamental_healthcheck(stock_symbol: str, depth: str = "standard") -> PromptMessage:
+    """Prompt for a comprehensive fundamental/financial-statement health check on a company."""
+    return company_fundamental_healthcheck_prompt(stock_symbol, depth)
+
+@mcp.prompt
+def pre_trade_risk_scan(market: str = "twse", stock_symbol: str = "") -> PromptMessage:
+    """Prompt for scanning disposal/warning/restriction lists before placing a trade."""
+    return pre_trade_risk_scan_prompt(market, stock_symbol)
 
 # Pass dependencies to tool registration
 register_all_tools(mcp, api_client)


### PR DESCRIPTION
## Summary
The existing 5 prompt templates (trend, foreign investment, dividend strategy, hotspot monitoring, investment screening) leave whole tool categories with no prompt guidance:
- The 16 TAIFEX futures/options tools (`tools/taifex/`) had zero prompt referencing them at all.
- 三大法人 (foreign/investment-trust/dealer) flow — arguably the single most common thing Taiwanese retail investors check daily — was scattered as a supporting bullet inside other prompts, with no dedicated chip-flow prompt.
- No prompt walked through a full financial-statement health check (income statement + balance sheet + revenue + EPS + profitability + dividend + governance in one pass).
- No prompt covered the pre-trade risk checklist (disposal stocks, warning stocks, day-trading restrictions, margin-loan restrictions) that a trader should sanity-check before buying.

## Changes
Adds 4 new prompts, following the existing convention established in #43 (Traditional Chinese, explicit anti-fabrication directive up front stating example numbers are format placeholders only, bracketed placeholders instead of invented figures in output-format sections):

- **`taifex_derivatives_prompt(scope)`** — put/call ratio, large-trader futures/options OI, 三大法人 futures/options positions, options delta/OI change, daily market reports, margin. `scope`: `sentiment` / `positioning` / `options_structure` / `comprehensive`.
- **`institutional_flow_prompt(target, stock_symbol)`** — TWSE/OTC 三大法人 buy/sell by market or by stock, foreign holdings concentration by industry. `target`: `market` / `stock` / `foreign_focus` / `otc`.
- **`company_fundamental_healthcheck_prompt(stock_symbol, depth)`** — profitability / growth / balance sheet / dividend policy / governance in one pass. `depth`: `quick` / `standard` / `deep`.
- **`pre_trade_risk_scan_prompt(market, stock_symbol)`** — cross-checks disposal/warning/notice/day-trading-restriction/margin-restriction lists. TWSE risk-list tools filter by `name` (company name substring) and OTC ones filter by `stock_no` (exact code) — these are genuinely different tool signatures, kept distinct in the prompt rather than papered over.

All 4 registered in `server.py` via `@mcp.prompt`. Updated the prompt count comment in `CLAUDE.md`/`AGENTS.md` from 5 to 9.

Every tool name/parameter referenced was verified against the actual `tools/` source (`grep`'d signatures) before writing the prompt text, not assumed.

## Test plan
- [x] `python -m py_compile` on all 4 new prompt files
- [x] Booted the actual `server.py` FastMCP instance — confirmed all 9 prompts register (`mcp.get_prompts()`), no import/registration errors, all existing tool modules still load
- [x] Called `mcp._prompt_manager.render_prompt(...)` for all 4 new prompts with representative args (including branch-specific args like `scope="positioning"`, `market="otc"`) — all render non-empty content with no runtime errors