### PR TITLE
feat: add TAIFEX futures/institutional historical data tools

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,7 +53,11 @@ tools/
 ├── otc/                      # TPEx OTC market: daily_close, institutional, peratio
 └── taifex/                   # TAIFEX derivatives: futures_position, put_call_ratio, institutional_general,
                               #   institutional_details, daily_market_report, large_traders_oi,
-                              #   options_analytics, margin, trading_statistics
+                              #   options_analytics, margin, trading_statistics, futures_daily_history,
+                              #   institutional_futures_history (latter two scrape www.taifex.com.tw's
+                              #   HTML-form download endpoints for multi-day history; openapi.taifex.com.tw
+                              #   has no historical query support — every openapi endpoint returns only
+                              #   the latest trading day, confirmed by testing all 135 of its endpoints)
 prompts/                      # 9 prompt templates registered in server.py
 ```
 

--- a/tests/e2e/test_taifex_history_api.py
+++ b/tests/e2e/test_taifex_history_api.py
@@ -1,0 +1,74 @@
+"""測試 www.taifex.com.tw 期交所歷史資料下載端點（Big5 CSV，非 openapi.taifex.com.tw）。
+只驗證 tool 依欄位「順序」（index）存取時，欄位順序未被期交所調整。
+"""
+
+import csv
+import io
+
+import requests
+
+HEADERS = {
+    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36",
+}
+
+
+def _post_csv(url: str, data: dict) -> list:
+    resp = requests.post(url, headers=HEADERS, data=data, verify=False, timeout=20)
+    text = resp.content.decode("big5", errors="replace")
+    return list(csv.reader(io.StringIO(text)))
+
+
+class TestFuturesDailyHistoryAPI:
+    """Tool get_futures_daily_history 依 index 存取的欄位順序：
+    0=交易日期 1=契約 2=到期月份(週別) 3=開盤價 4=最高價 5=最低價 6=收盤價
+    7=漲跌價 8=漲跌% 9=成交量 10=結算價 11=未沖銷契約數 ... 17=交易時段
+    """
+
+    def test_hardcoded_column_order(self):
+        rows = _post_csv(
+            "https://www.taifex.com.tw/cht/3/futDataDown",
+            {
+                "down_type": "1",
+                "commodity_id": "TX",
+                "commodity_id2": "",
+                "queryStartDate": "2026/07/01",
+                "queryEndDate": "2026/07/03",
+            },
+        )
+        assert len(rows) > 1, "查無資料，無法驗證欄位順序"
+        header = rows[0]
+        expected = [
+            "交易日期", "契約", "到期月份(週別)", "開盤價", "最高價", "最低價", "收盤價",
+            "漲跌價", "漲跌%", "成交量", "結算價", "未沖銷契約數",
+        ]
+        assert header[:len(expected)] == expected, f"欄位順序異動: {header}"
+        assert header[17] == "交易時段", f"交易時段欄位位置異動: {header}"
+
+
+class TestInstitutionalTradersByFuturesHistoryAPI:
+    """Tool get_institutional_traders_by_futures_history 依 index 存取的欄位順序：
+    0=日期 1=商品名稱 2=身份別 3=多方交易口數 4=多方交易契約金額(千元)
+    5=空方交易口數 6=空方交易契約金額(千元) 7=多空交易口數淨額 8=多空交易契約金額淨額(千元)
+    9=多方未平倉口數 10=多方未平倉契約金額(千元) 11=空方未平倉口數 12=空方未平倉契約金額(千元)
+    13=多空未平倉口數淨額 14=多空未平倉契約金額淨額(千元)
+    """
+
+    def test_hardcoded_column_order(self):
+        rows = _post_csv(
+            "https://www.taifex.com.tw/cht/3/futContractsDateDown",
+            {
+                "queryStartDate": "2026/06/01",
+                "queryEndDate": "2026/06/03",
+                "commodityId": "TXF",
+            },
+        )
+        assert len(rows) > 1, "查無資料，無法驗證欄位順序"
+        header = rows[0]
+        expected = [
+            "日期", "商品名稱", "身份別",
+            "多方交易口數", "多方交易契約金額(千元)", "空方交易口數", "空方交易契約金額(千元)",
+            "多空交易口數淨額", "多空交易契約金額淨額(千元)",
+            "多方未平倉口數", "多方未平倉契約金額(千元)", "空方未平倉口數", "空方未平倉契約金額(千元)",
+            "多空未平倉口數淨額", "多空未平倉契約金額淨額(千元)",
+        ]
+        assert header == expected, f"欄位順序異動: {header}"

--- a/tools/taifex/futures_daily_history.py
+++ b/tools/taifex/futures_daily_history.py
@@ -1,0 +1,94 @@
+"""TAIFEX futures daily OHLC history (multi-day download, not exposed via openapi.taifex.com.tw)."""
+
+import csv
+import io
+from datetime import datetime
+from typing import Optional
+from fastmcp import FastMCP
+from utils import TWSEAPIClient, handle_api_errors
+from .futures_position import TAIFEX_HEADERS
+
+# www.taifex.com.tw's HTML-form download endpoint — distinct from openapi.taifex.com.tw's
+# DailyMarketReportFut, which only ever returns the latest trading day with no date param.
+# Confirmed by live testing: this endpoint accepts an arbitrary date range (max ~1 month per
+# call, enforced client-side here since the server silently returns an empty/invalid body
+# instead of an error when exceeded) and returns real historical OHLC per contract month.
+FUT_DATA_DOWN_URL = "https://www.taifex.com.tw/cht/3/futDataDown"
+
+MAX_SPAN_DAYS = 31
+
+
+def _parse_yyyymmdd(value: str) -> datetime:
+    return datetime.strptime(value, "%Y%m%d")
+
+
+def register_tools(mcp: FastMCP, client: Optional[TWSEAPIClient] = None) -> None:
+    """Register TAIFEX futures daily OHLC history tools."""
+    _client = client or TWSEAPIClient.get_instance()
+
+    @mcp.tool
+    @handle_api_errors()
+    def get_futures_daily_history(start_date: str, end_date: str, contract: str = "TX") -> str:
+        """查詢期貨每日OHLC歷史行情（可回溯查詢，非僅最新一日）。
+        資料來源為期交所網站下載頁面（www.taifex.com.tw），非 openapi.taifex.com.tw
+        （openapi 版的 get_daily_futures_market_report 僅能查最新一個交易日，無法回溯）。
+        實測資料至少可回溯至 2020 年。
+
+        Args:
+            start_date: 起始日期，格式 YYYYMMDD，例如 "20260601"
+            end_date: 結束日期，格式 YYYYMMDD。與 start_date 區間不可超過一個月
+            contract: 期貨契約代碼，預設 TX（臺股期貨）。其他常用：MTX（小型臺指）、
+                TE（電子期貨）、TF（金融期貨）。與 get_institutional_traders_by_futures_history
+                的契約代碼（TXF/EXF/FXF...）為不同代碼系統，不可混用
+
+        Returns:
+            區間內每個交易日、每個到期月份、一般與盤後時段的開高低收、成交量、未平倉資訊
+        """
+        try:
+            start_dt = _parse_yyyymmdd(start_date)
+            end_dt = _parse_yyyymmdd(end_date)
+        except ValueError:
+            return f"日期格式錯誤，請使用 YYYYMMDD 格式（例如 20260601），收到：start_date={start_date}, end_date={end_date}"
+
+        if start_dt > end_dt:
+            return f"起始日期 {start_date} 不可晚於結束日期 {end_date}"
+        if (end_dt - start_dt).days > MAX_SPAN_DAYS:
+            return f"查詢區間不可超過一個月（收到 {(end_dt - start_dt).days} 天），請縮小 start_date～end_date 範圍後重試"
+
+        contract = contract.strip().upper()
+        body = _client.fetch_bytes(
+            FUT_DATA_DOWN_URL,
+            method="POST",
+            headers=TAIFEX_HEADERS,
+            data={
+                "down_type": "1",
+                "commodity_id": contract,
+                "commodity_id2": "",
+                "queryStartDate": start_dt.strftime("%Y/%m/%d"),
+                "queryEndDate": end_dt.strftime("%Y/%m/%d"),
+            },
+        )
+        text = body.decode("big5", errors="replace")
+
+        if "DateTime error" in text or text.lstrip().lower().startswith("<html"):
+            return f"查詢失敗，日期區間可能超出資料範圍（{start_date}～{end_date}）或格式有誤"
+
+        rows = list(csv.reader(io.StringIO(text)))
+        if len(rows) < 2:
+            return f"查無契約 {contract} 在 {start_date}～{end_date} 的行情資料，請確認契約代碼是否正確"
+
+        header, data_rows = rows[0], rows[1:]
+        data_rows = [r for r in data_rows if len(r) >= len(header) and r[0].strip()]
+        if not data_rows:
+            return f"查無契約 {contract} 在 {start_date}～{end_date} 的行情資料（可能非交易日或契約代碼錯誤）"
+
+        lines = [f"【期貨每日OHLC歷史行情】契約:{contract} 區間:{start_date}~{end_date}（共 {len(data_rows)} 筆）\n"]
+        for r in data_rows:
+            date, _contract, month, o, h, l, c = r[0], r[1], r[2].strip(), r[3], r[4], r[5], r[6]
+            change, pct, vol, settle, oi, session = r[7], r[8], r[9], r[10], r[11], r[17]
+            lines.append(
+                f"{date} | {month} | {session} | 開:{o} 高:{h} 低:{l} 收:{c} | "
+                f"漲跌:{change}({pct}) | 量:{vol} | 結算:{settle} | 未平倉:{oi}"
+            )
+
+        return "\n".join(lines)

--- a/tools/taifex/futures_daily_history.py
+++ b/tools/taifex/futures_daily_history.py
@@ -1,9 +1,14 @@
-"""TAIFEX futures daily OHLC history (multi-day download, not exposed via openapi.taifex.com.tw)."""
+"""TAIFEX futures daily OHLC history (multi-day download, not exposed via openapi.taifex.com.tw).
+
+Also home to the shared helpers for parsing/decoding www.taifex.com.tw's HTML-form CSV
+download responses, reused by institutional_futures_history.py — the same pattern as
+TAIFEX_HEADERS living in futures_position.py and being imported by sibling modules.
+"""
 
 import csv
 import io
 from datetime import datetime
-from typing import Optional
+from typing import List, Optional, Tuple
 from fastmcp import FastMCP
 from utils import TWSEAPIClient, handle_api_errors
 from .futures_position import TAIFEX_HEADERS
@@ -18,8 +23,31 @@ FUT_DATA_DOWN_URL = "https://www.taifex.com.tw/cht/3/futDataDown"
 MAX_SPAN_DAYS = 31
 
 
-def _parse_yyyymmdd(value: str) -> datetime:
+def parse_yyyymmdd(value: str) -> datetime:
     return datetime.strptime(value, "%Y%m%d")
+
+
+def decode_and_parse_csv(body: bytes) -> Optional[Tuple[List[str], List[List[str]]]]:
+    """Decode a Big5 CSV response body from a www.taifex.com.tw download endpoint.
+
+    These endpoints return an HTML alert page (not an HTTP error status) when the query is
+    rejected (bad/out-of-range dates), so that case is detected here and signaled as None
+    rather than surfaced as parsed rows. Returns (header, data_rows) on success.
+    """
+    text = body.decode("big5", errors="replace")
+    if "DateTime error" in text or text.lstrip().lower().startswith("<html"):
+        return None
+
+    rows = list(csv.reader(io.StringIO(text)))
+    if len(rows) < 2:
+        return None
+
+    header, data_rows = rows[0], rows[1:]
+    data_rows = [r for r in data_rows if len(r) >= len(header) and r[0].strip()]
+    if not data_rows:
+        return None
+
+    return header, data_rows
 
 
 def register_tools(mcp: FastMCP, client: Optional[TWSEAPIClient] = None) -> None:
@@ -45,8 +73,8 @@ def register_tools(mcp: FastMCP, client: Optional[TWSEAPIClient] = None) -> None
             區間內每個交易日、每個到期月份、一般與盤後時段的開高低收、成交量、未平倉資訊
         """
         try:
-            start_dt = _parse_yyyymmdd(start_date)
-            end_dt = _parse_yyyymmdd(end_date)
+            start_dt = parse_yyyymmdd(start_date)
+            end_dt = parse_yyyymmdd(end_date)
         except ValueError:
             return f"日期格式錯誤，請使用 YYYYMMDD 格式（例如 20260601），收到：start_date={start_date}, end_date={end_date}"
 
@@ -68,20 +96,11 @@ def register_tools(mcp: FastMCP, client: Optional[TWSEAPIClient] = None) -> None
                 "queryEndDate": end_dt.strftime("%Y/%m/%d"),
             },
         )
-        text = body.decode("big5", errors="replace")
+        parsed = decode_and_parse_csv(body)
+        if parsed is None:
+            return f"查無契約 {contract} 在 {start_date}～{end_date} 的行情資料，請確認契約代碼是否正確、日期區間是否為交易日"
 
-        if "DateTime error" in text or text.lstrip().lower().startswith("<html"):
-            return f"查詢失敗，日期區間可能超出資料範圍（{start_date}～{end_date}）或格式有誤"
-
-        rows = list(csv.reader(io.StringIO(text)))
-        if len(rows) < 2:
-            return f"查無契約 {contract} 在 {start_date}～{end_date} 的行情資料，請確認契約代碼是否正確"
-
-        header, data_rows = rows[0], rows[1:]
-        data_rows = [r for r in data_rows if len(r) >= len(header) and r[0].strip()]
-        if not data_rows:
-            return f"查無契約 {contract} 在 {start_date}～{end_date} 的行情資料（可能非交易日或契約代碼錯誤）"
-
+        _header, data_rows = parsed
         lines = [f"【期貨每日OHLC歷史行情】契約:{contract} 區間:{start_date}~{end_date}（共 {len(data_rows)} 筆）\n"]
         for r in data_rows:
             date, _contract, month, o, h, l, c = r[0], r[1], r[2].strip(), r[3], r[4], r[5], r[6]

--- a/tools/taifex/institutional_futures_history.py
+++ b/tools/taifex/institutional_futures_history.py
@@ -1,0 +1,107 @@
+"""TAIFEX 三大法人 futures position history by contract, by date (multi-day download).
+
+Distinct data source from tools/taifex/institutional_details.py's get_institutional_traders_by_futures,
+which hits openapi.taifex.com.tw and only ever returns the latest trading day. This module scrapes
+www.taifex.com.tw's HTML-form download endpoint, which genuinely accepts an arbitrary date range.
+"""
+
+import csv
+import io
+from datetime import datetime
+from typing import Optional
+from fastmcp import FastMCP
+from utils import TWSEAPIClient, handle_api_errors
+from .futures_position import TAIFEX_HEADERS
+
+FUT_CONTRACTS_DATE_DOWN_URL = "https://www.taifex.com.tw/cht/3/futContractsDateDown"
+
+# Server does not enforce a hard span cap (tested 6 months successfully), but responses grow
+# ~3 rows/trading-day/contract (dealer/investment trust/foreign), so cap client-side to keep
+# tool output manageable.
+MAX_SPAN_DAYS = 92
+
+
+def _parse_yyyymmdd(value: str) -> datetime:
+    return datetime.strptime(value, "%Y%m%d")
+
+
+def register_tools(mcp: FastMCP, client: Optional[TWSEAPIClient] = None) -> None:
+    """Register TAIFEX institutional futures position history tools."""
+    _client = client or TWSEAPIClient.get_instance()
+
+    @mcp.tool
+    @handle_api_errors()
+    def get_institutional_traders_by_futures_history(start_date: str, end_date: str, contract: str = "TXF") -> str:
+        """查詢三大法人期貨部位歷史資料（可回溯查詢，非僅最新一日）。
+        資料來源為期交所網站下載頁面（www.taifex.com.tw），非 openapi.taifex.com.tw
+        （openapi 版的 get_institutional_traders_by_futures 僅能查最新一個交易日，無法回溯）。
+        實測資料約可回溯至 2023 年下半年（更早日期會查詢失敗），區間不可超過 3 個月。
+
+        Args:
+            start_date: 起始日期，格式 YYYYMMDD，例如 "20260601"
+            end_date: 結束日期，格式 YYYYMMDD。與 start_date 區間不可超過 92 天
+            contract: 期貨契約代碼，預設 TXF（臺股期貨）。留空則查詢全部契約（資料量較大）。
+                其他常用：MXF（小型臺指）、EXF（電子期貨）、FXF（金融期貨）、TMF（微型臺指）。
+                與 get_futures_daily_history 的契約代碼（TX/MTX/TE/TF...）為不同代碼系統，不可混用
+
+        Returns:
+            區間內每個交易日、自營商/投信/外資及陸資的多空交易口數、契約金額、未平倉資訊
+        """
+        try:
+            start_dt = _parse_yyyymmdd(start_date)
+            end_dt = _parse_yyyymmdd(end_date)
+        except ValueError:
+            return f"日期格式錯誤，請使用 YYYYMMDD 格式（例如 20260601），收到：start_date={start_date}, end_date={end_date}"
+
+        if start_dt > end_dt:
+            return f"起始日期 {start_date} 不可晚於結束日期 {end_date}"
+        if (end_dt - start_dt).days > MAX_SPAN_DAYS:
+            return f"查詢區間不可超過 {MAX_SPAN_DAYS} 天（收到 {(end_dt - start_dt).days} 天），請縮小 start_date～end_date 範圍後重試"
+
+        contract = contract.strip().upper()
+        body = _client.fetch_bytes(
+            FUT_CONTRACTS_DATE_DOWN_URL,
+            method="POST",
+            headers=TAIFEX_HEADERS,
+            data={
+                "queryStartDate": start_dt.strftime("%Y/%m/%d"),
+                "queryEndDate": end_dt.strftime("%Y/%m/%d"),
+                "commodityId": contract,
+            },
+        )
+        text = body.decode("big5", errors="replace")
+
+        if "DateTime error" in text or text.lstrip().lower().startswith("<html"):
+            return (
+                f"查詢失敗，日期區間可能超出資料保存範圍（約近 3 年內）或格式有誤："
+                f"{start_date}～{end_date}"
+            )
+
+        rows = list(csv.reader(io.StringIO(text)))
+        if len(rows) < 2:
+            contract_label = contract or "全部契約"
+            return f"查無契約 {contract_label} 在 {start_date}～{end_date} 的三大法人資料，請確認契約代碼是否正確"
+
+        header, data_rows = rows[0], rows[1:]
+        data_rows = [r for r in data_rows if len(r) >= len(header) and r[0].strip()]
+        if not data_rows:
+            contract_label = contract or "全部契約"
+            return f"查無契約 {contract_label} 在 {start_date}～{end_date} 的三大法人資料（可能非交易日或契約代碼錯誤）"
+
+        contract_label = contract or "全部契約"
+        lines = [
+            f"【三大法人期貨部位歷史】契約:{contract_label} 區間:{start_date}~{end_date}（共 {len(data_rows)} 筆）\n"
+        ]
+        for r in data_rows:
+            date, name, identity = r[0], r[1], r[2]
+            long_vol, long_amt = r[3], r[4]
+            short_vol, short_amt = r[5], r[6]
+            net_vol, net_amt = r[7], r[8]
+            oi_long, oi_short, oi_net = r[9], r[11], r[13]
+            lines.append(
+                f"{date} | {name} | {identity}\n"
+                f"  交易: 多 {long_vol}({long_amt}千元) / 空 {short_vol}({short_amt}千元) / 淨 {net_vol}({net_amt}千元)\n"
+                f"  未平倉: 多 {oi_long} / 空 {oi_short} / 淨 {oi_net}"
+            )
+
+        return "\n".join(lines)

--- a/tools/taifex/institutional_futures_history.py
+++ b/tools/taifex/institutional_futures_history.py
@@ -5,13 +5,11 @@ which hits openapi.taifex.com.tw and only ever returns the latest trading day. T
 www.taifex.com.tw's HTML-form download endpoint, which genuinely accepts an arbitrary date range.
 """
 
-import csv
-import io
-from datetime import datetime
 from typing import Optional
 from fastmcp import FastMCP
 from utils import TWSEAPIClient, handle_api_errors
 from .futures_position import TAIFEX_HEADERS
+from .futures_daily_history import parse_yyyymmdd, decode_and_parse_csv
 
 FUT_CONTRACTS_DATE_DOWN_URL = "https://www.taifex.com.tw/cht/3/futContractsDateDown"
 
@@ -19,10 +17,6 @@ FUT_CONTRACTS_DATE_DOWN_URL = "https://www.taifex.com.tw/cht/3/futContractsDateD
 # ~3 rows/trading-day/contract (dealer/investment trust/foreign), so cap client-side to keep
 # tool output manageable.
 MAX_SPAN_DAYS = 92
-
-
-def _parse_yyyymmdd(value: str) -> datetime:
-    return datetime.strptime(value, "%Y%m%d")
 
 
 def register_tools(mcp: FastMCP, client: Optional[TWSEAPIClient] = None) -> None:
@@ -48,8 +42,8 @@ def register_tools(mcp: FastMCP, client: Optional[TWSEAPIClient] = None) -> None
             區間內每個交易日、自營商/投信/外資及陸資的多空交易口數、契約金額、未平倉資訊
         """
         try:
-            start_dt = _parse_yyyymmdd(start_date)
-            end_dt = _parse_yyyymmdd(end_date)
+            start_dt = parse_yyyymmdd(start_date)
+            end_dt = parse_yyyymmdd(end_date)
         except ValueError:
             return f"日期格式錯誤，請使用 YYYYMMDD 格式（例如 20260601），收到：start_date={start_date}, end_date={end_date}"
 
@@ -69,26 +63,15 @@ def register_tools(mcp: FastMCP, client: Optional[TWSEAPIClient] = None) -> None
                 "commodityId": contract,
             },
         )
-        text = body.decode("big5", errors="replace")
-
-        if "DateTime error" in text or text.lstrip().lower().startswith("<html"):
+        parsed = decode_and_parse_csv(body)
+        contract_label = contract or "全部契約"
+        if parsed is None:
             return (
-                f"查詢失敗，日期區間可能超出資料保存範圍（約近 3 年內）或格式有誤："
-                f"{start_date}～{end_date}"
+                f"查無契約 {contract_label} 在 {start_date}～{end_date} 的三大法人資料，"
+                f"請確認契約代碼是否正確；日期區間也可能超出資料保存範圍（約近 3 年內）"
             )
 
-        rows = list(csv.reader(io.StringIO(text)))
-        if len(rows) < 2:
-            contract_label = contract or "全部契約"
-            return f"查無契約 {contract_label} 在 {start_date}～{end_date} 的三大法人資料，請確認契約代碼是否正確"
-
-        header, data_rows = rows[0], rows[1:]
-        data_rows = [r for r in data_rows if len(r) >= len(header) and r[0].strip()]
-        if not data_rows:
-            contract_label = contract or "全部契約"
-            return f"查無契約 {contract_label} 在 {start_date}～{end_date} 的三大法人資料（可能非交易日或契約代碼錯誤）"
-
-        contract_label = contract or "全部契約"
+        _header, data_rows = parsed
         lines = [
             f"【三大法人期貨部位歷史】契約:{contract_label} 區間:{start_date}~{end_date}（共 {len(data_rows)} 筆）\n"
         ]

--- a/utils/api_client.py
+++ b/utils/api_client.py
@@ -52,13 +52,17 @@ class TWSEAPIClient:
         params: Optional[Dict[str, Any]] = None,
         headers: Optional[Dict[str, str]] = None,
         timeout: float = APIConfig.DEFAULT_TIMEOUT,
+        method: str = "GET",
+        data: Optional[Dict[str, Any]] = None,
     ) -> requests.Response:
-        """Throttle, send GET, stamp last-request time, and return the response."""
+        """Throttle, send GET/POST, stamp last-request time, and return the response."""
         self._throttle()
-        logger.info(f"Fetching {url} params={params}")
-        resp = requests.get(
+        logger.info(f"Fetching {method} {url} params={params}")
+        resp = requests.request(
+            method,
             url,
             params=params,
+            data=data,
             headers=headers or {"User-Agent": self.user_agent, "Accept": "application/json"},
             verify=self.verify_ssl,
             timeout=timeout,
@@ -134,6 +138,26 @@ class TWSEAPIClient:
             return self._request(url, params=params, headers=headers, timeout=timeout).json()
         except Exception as e:
             logger.error(f"Failed to fetch JSON from {url}: {e}")
+            raise
+
+    def fetch_bytes(
+        self,
+        url: str,
+        data: Optional[Dict[str, Any]] = None,
+        params: Optional[Dict[str, Any]] = None,
+        headers: Optional[Dict[str, str]] = None,
+        timeout: float = APIConfig.DEFAULT_TIMEOUT,
+        method: str = "GET",
+    ) -> bytes:
+        """Fetch raw response bytes from an arbitrary full URL, supporting POST form submissions.
+
+        Used for HTML-form download endpoints that return non-JSON bodies (e.g. Big5-encoded
+        CSV from www.taifex.com.tw's data-download pages), which callers decode themselves.
+        """
+        try:
+            return self._request(url, params=params, data=data, headers=headers, timeout=timeout, method=method).content
+        except Exception as e:
+            logger.error(f"Failed to fetch bytes from {url}: {e}")
             raise
 
     @classmethod


### PR DESCRIPTION
## Summary

`openapi.taifex.com.tw` has **no historical query support anywhere**. Verified this empirically, not from docs: tried 11 common date-param names against `DailyMarketReportFut`, all ignored; then live-tested all 135 endpoints in the OpenAPI, checking which ones return more than one distinct date without any param. The only 2 endpoints with OHLC fields (`DailyMarketReportFut`/`DailyMarketReportOpt`, already wrapped by the existing `get_daily_futures_market_report`/`get_daily_options_market_report`) are hard-locked to "latest trading day only" — confirmed the returned date advanced from `20260716` to `20260717` between two calls minutes apart.

`www.taifex.com.tw`'s own HTML-form data-download pages, however, genuinely support arbitrary historical ranges. Found these by browsing the site (not guessing URLs), then reverse-engineered the actual POST request each form fires by inspecting network traffic after programmatically submitting the form — the visible UI's date-picker/button setup isn't directly scriptable, but the underlying request is simple POST form data.

## New tools

- **`get_futures_daily_history(start_date, end_date, contract="TX")`** — POST `/cht/3/futDataDown`. Daily OHLC per contract-month/session. Server enforces ~1 month max span (returns an invalid/empty body past that, now validated client-side before the call). Retention verified back to at least 2020.
- **`get_institutional_traders_by_futures_history(start_date, end_date, contract="TXF")`** — POST `/cht/3/futContractsDateDown`. 三大法人 (dealer/investment trust/foreign) long/short volume + OI per contract per day. No server-side span cap observed (tested a clean 6-month pull), capped client-side at 92 days to bound tool output. Retention cutoff empirically narrowed to somewhere between 2023/06 and 2023/09 (older dates return a `DateTime error` HTML page, now detected and turned into a friendly message).

**Important**: these two tools use a different commodity/contract code space than the existing openapi-backed tools (e.g. `TX` vs `TXF` for 臺股期貨, `TE` vs `EXF` for 電子期貨 — confirmed by cross-checking the actual dropdown option labels on both pages, not assumed). Both docstrings call this out explicitly so the two aren't mixed up.

## Supporting change

`TWSEAPIClient` only supported GET+JSON (`fetch_json`) and GET+JSON-list (`fetch_data`). These new endpoints return Big5-encoded CSV via POST, so added `fetch_bytes()` (plus POST support in the shared `_request()`) rather than bypassing the client's throttling in the new tool modules.

## Test plan
- [x] `python -m py_compile` on all changed/new files
- [x] Booted the real `server.py` FastMCP instance and called both new tools through `mcp._tool_manager.call_tool(...)` with live network requests — verified real multi-day output (157 rows / 12 days for the futures history call, 24 rows / 3 days×3-identities for the institutional call)
- [x] Verified error paths live: >1 month span → friendly rejection before any network call; date outside retention (`2020/06/01`) → friendly message instead of a raw HTML error dump
- [x] Added `tests/e2e/test_taifex_history_api.py` asserting the CSV column order both tools access by index (per the repo's "non-TWSE-OpenAPI sources get a `test_hardcoded_fields_exist`-style test" convention) — 2 passed
- [x] Ran the full existing TAIFEX e2e suite (`test_taifex_api.py` + `test_taifex_batch2_api.py` + `test_taifex_new_api.py` + the new file) — 29 passed, no regressions
- [x] Unit-tested `fetch_bytes()` with a mocked POST to confirm method/data are threaded through correctly