### PR TITLE
feat: add TWSE Tier 1 historical-data tools (5 new tools)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 TWStockMCPServer is a Model Context Protocol (MCP) server for Taiwan stock market data analysis. Built with FastMCP (Python) and `requests`. Data sources:
 - **TWSE OpenAPI** (`openapi.twse.com.tw`) — 143 tools: 公司治理、ESG、財報、交易、指數、券商
-- **TWSE Web API** (`twse.com.tw`) — 6 tools: 歷史日K、月均價、估值、融資融券（`/exchangeReport`）；三大法人買賣超日報、個股明細（`/rwd/zh/fund/T86`）（legacy JSON，非 Swagger）
+- **TWSE Web API** (`twse.com.tw`) — 11 tools: 歷史日K、月均價、估值、融資融券（`/exchangeReport`）；三大法人買賣超日報、個股明細（`/rwd/zh/fund/T86`）；三大法人買賣金額、全市場收盤行情、市場成交量值、加權指數歷史、外資持股歷史（`/rwd/zh/...`，可查任意過去日期，與同名 openapi.twse.com.tw 端點僅回傳最近約12個交易日不同）（legacy JSON，非 Swagger）
 - **MIS 即時報價** (`mis.twse.com.tw`) — 1 tool: 盤中多股即時報價
 - **TPEx OpenAPI** (`tpex.org.tw/openapi`) — 3 tools: 上櫃日收盤、三大法人、本益比
 - **TAIFEX OpenAPI** (`openapi.taifex.com.tw`) — 16 tools: 三大法人系列、大額交易人部位、每日行情、選擇權分析（Delta/OI增減）、保證金、年月統計

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,10 @@ tools/
 ├── company/                  # Company tools: basic_info, financials, esg, listing, news
 ├── trading/                  # Trading tools: daily, periodic, valuation, dividend_schedule, etf, market, warrants
 ├── market/                   # Market tools: indices, statistics, foreign
-├── history/                  # TWSE legacy: stock_day, stock_day_avg, bwibbu_all, margin_balance (exchangeReport); institutional (T86)
+├── history/                  # TWSE legacy: stock_day, stock_day_avg, bwibbu_all, margin_balance (exchangeReport); institutional (T86);
+                              #   institutional_amounts, all_stocks_daily_close, market_turnover, taiex_index_history,
+                              #   foreign_holdings_history (rwd/* endpoints — accept arbitrary past dates, unlike the
+                              #   openapi.twse.com.tw equivalents which only return a rolling ~12-day window)
 ├── realtime/                 # MIS real-time quotes: stock_info
 ├── otc/                      # TPEx OTC market: daily_close, institutional, peratio
 └── taifex/                   # TAIFEX derivatives: futures_position, put_call_ratio, institutional_general,

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ uv sync && uv run fastmcp dev server.py
 | 來源 | 說明 | Tools |
 |------|------|-------|
 | [TWSE OpenAPI](https://openapi.twse.com.tw) | 台灣證交所官方 API — 公司治理、ESG、財報、交易、指數等 | 143 個 |
-| [TWSE Web API](https://www.twse.com.tw) | 證交所網頁 API — 個股日K、月均價、估值、融資融券、上市三大法人買賣超 | 6 個 |
+| [TWSE Web API](https://www.twse.com.tw) | 證交所網頁 API — 個股日K、月均價、估值、融資融券、上市三大法人買賣超（金額/股數）、全市場收盤行情、加權指數歷史、外資持股歷史 | 11 個 |
 | [MIS 即時報價](https://mis.twse.com.tw) | 盤中即時多股報價（上市+上櫃） | 1 個 |
 | [TPEx OpenAPI](https://www.tpex.org.tw/openapi) | 櫃買中心 — 上櫃日收盤、三大法人（個股/彙總）、本益比、融資融券、注意/處置股、除權息、零股、指數 | 10 個 |
 | [TAIFEX OpenAPI](https://openapi.taifex.com.tw) | 期交所 — 三大法人系列、大額交易人部位、每日行情、選擇權分析、保證金、年月統計 | 16 個 |

--- a/README_en-us.md
+++ b/README_en-us.md
@@ -116,7 +116,7 @@ uv sync && uv run fastmcp dev server.py
 | Source | Description | Tools |
 |--------|-------------|-------|
 | [TWSE OpenAPI](https://openapi.twse.com.tw) | Taiwan Stock Exchange official API — corporate governance, ESG, financials, trading, indices, etc. | 143 |
-| [TWSE Web API](https://www.twse.com.tw) | TWSE web API endpoints — daily OHLC, monthly avg price, valuation, margin balance, listed stocks institutional investors | 6 |
+| [TWSE Web API](https://www.twse.com.tw) | TWSE web API endpoints — daily OHLC, monthly avg price, valuation, margin balance, listed stocks institutional investors (amounts/shares), whole-market daily close, TAIEX index history, foreign holdings history | 11 |
 | [MIS Real-time Quotes](https://mis.twse.com.tw) | Intraday real-time multi-stock quotes (listed + OTC) | 1 |
 | [TPEx OpenAPI](https://www.tpex.org.tw/openapi) | TPEx OTC market — daily close, institutional investors (per-stock/summary), P/E ratio, margin balance, warning/disposal stocks, ex-rights/dividends, odd-lot, index | 10 |
 | [TAIFEX OpenAPI](https://openapi.taifex.com.tw) | TAIFEX derivatives — institutional series, large traders OI, daily market report, options analytics, margin, statistics | 16 |

--- a/tests/e2e/test_history_tier1_api.py
+++ b/tests/e2e/test_history_tier1_api.py
@@ -1,0 +1,106 @@
+"""
+測試 www.twse.com.tw/rwd 五個新增歷史查詢 API（NEW_TOOLS_PLAN.md Tier 1）。
+只驗證 tools 中有寫死用到的欄位索引/位置，足以偵測來源 API 結構異動。
+"""
+
+import pytest
+from tests.helpers import fetch_or_skip
+
+FIXED_DATE = "20250103"  # 固定歷史交易日，確保資料穩定
+FIXED_STOCK = "2330"     # 台積電
+
+
+class TestMarketInstitutionalAmountsAPI:
+    """三大法人買賣金額統計 - BFI82U
+    Tool get_market_institutional_amounts_history 使用 row[0]~row[3]：
+    單位名稱、買進金額、賣出金額、買賣差額。
+    """
+
+    def test_row_has_name_and_three_amount_fields(self):
+        result = fetch_or_skip(
+            "https://www.twse.com.tw/rwd/zh/fund/BFI82U",
+            params={"response": "json", "dayDate": FIXED_DATE, "type": "day"},
+        )
+        assert result.get("stat") == "OK"
+        data = result.get("data", [])
+        assert len(data) > 0
+        row = data[0]
+        assert len(row) >= 4, f"欄位數不足 4，row 結構可能已變更: {row}"
+        assert "合計" in [r[0] for r in data], "找不到「合計」列，row[0] 單位名稱欄位可能已變更"
+
+
+class TestAllStocksDailyCloseAPI:
+    """全市場每日收盤行情 - MI_INDEX
+    Tool get_all_stocks_daily_close 從 tables 中找標題含「每日收盤行情」的 table，
+    使用該 table 的 row[0]~row[15]：代號、名稱、量、筆數、金額、開高低收、漲跌、
+    漲跌價差、買賣揭示、本益比。
+    """
+
+    def test_stock_table_exists_with_16_columns(self):
+        result = fetch_or_skip(
+            "https://www.twse.com.tw/rwd/zh/afterTrading/MI_INDEX",
+            params={"response": "json", "date": FIXED_DATE, "type": "ALLBUT0999"},
+        )
+        assert result.get("stat") == "OK"
+        tables = result.get("tables", [])
+        stock_table = next(
+            (t for t in tables if "每日收盤行情" in (t.get("title") or "")), None
+        )
+        assert stock_table is not None, "找不到標題含「每日收盤行情」的 table，tables 結構可能已變更"
+        data = stock_table.get("data", [])
+        assert len(data) > 0
+        assert len(data[0]) >= 16, f"欄位數不足 16，row 結構可能已變更: {data[0]}"
+
+
+class TestMarketTurnoverHistoryAPI:
+    """每日市場成交資訊 - FMTQIK
+    Tool get_market_turnover_history 使用 row[0]~row[5]：
+    日期、成交股數、成交金額、成交筆數、加權指數、漲跌點數。
+    """
+
+    def test_row_has_6_columns(self):
+        result = fetch_or_skip(
+            "https://www.twse.com.tw/rwd/zh/afterTrading/FMTQIK",
+            params={"response": "json", "date": FIXED_DATE},
+        )
+        assert result.get("stat") == "OK"
+        data = result.get("data", [])
+        assert len(data) > 0
+        assert len(data[0]) == 6, f"欄位數不為 6，row 結構可能已變更: {data[0]}"
+
+
+class TestTaiexIndexHistoryAPI:
+    """加權股價指數歷史 - MI_5MINS_HIST
+    Tool get_taiex_index_history 使用 row[0]~row[4]：
+    日期、開盤指數、最高指數、最低指數、收盤指數。
+    """
+
+    def test_row_has_5_columns(self):
+        result = fetch_or_skip(
+            "https://www.twse.com.tw/rwd/zh/TAIEX/MI_5MINS_HIST",
+            params={"response": "json", "date": FIXED_DATE},
+        )
+        assert result.get("stat") == "OK"
+        data = result.get("data", [])
+        assert len(data) > 0
+        assert len(data[0]) == 5, f"欄位數不為 5，row 結構可能已變更: {data[0]}"
+
+
+class TestForeignHoldingsHistoryAPI:
+    """外資及陸資持股統計 - MI_QFIIS
+    Tool get_foreign_holdings_history 使用 row[0],row[1],row[3]~row[7]：
+    代號、名稱、發行股數、尚可投資股數、持有股數、尚可投資比率、持股比率。
+    """
+
+    def test_row_has_stock_code_and_holding_fields(self):
+        result = fetch_or_skip(
+            "https://www.twse.com.tw/rwd/zh/fund/MI_QFIIS",
+            params={"response": "json", "date": FIXED_DATE, "selectType": "ALLBUT0999"},
+        )
+        assert result.get("stat") == "OK"
+        data = result.get("data", [])
+        assert len(data) > 0
+        tsmc = next((r for r in data if r[0] == FIXED_STOCK), None)
+        assert tsmc is not None, f"{FIXED_STOCK} 不在資料中，row[0] 可能已不再是股票代號"
+        assert len(tsmc) >= 8, f"欄位數不足 8，row 結構可能已變更: {tsmc}"
+        float(str(tsmc[7]))  # 持股比率需可轉數字，拋出例外即代表欄位位移

--- a/tools/history/all_stocks_daily_close.py
+++ b/tools/history/all_stocks_daily_close.py
@@ -19,13 +19,15 @@ def register_tools(mcp: FastMCP, client: Optional[TWSEAPIClient] = None) -> None
 
     @mcp.tool
     @handle_api_errors()
-    def get_all_stocks_daily_close(date: str, name: str = "", limit: int = DEFAULT_DISPLAY_LIMIT, offset: int = 0) -> str:
+    def get_all_stocks_daily_close(date: str, stock_no: str = "", name: str = "",
+                                    limit: int = DEFAULT_DISPLAY_LIMIT, offset: int = 0) -> str:
         """查詢指定日期全部上市股票的每日收盤行情（開高低收、成交量、本益比）。
         與 get_stock_history（單一股票查一整月）互補：此工具是「單一日期查全市場」，
         適合抓某天的市場快照或篩選特定條件的股票。
 
         Args:
             date: 查詢日期，格式 YYYYMMDD，例如 "20260610"（需為交易日）
+            stock_no: 股票代號（選填），指定則只回傳該股票
             name: 股票名稱關鍵字（選填）
             limit: 回傳筆數上限（預設 50）
             offset: 跳過前 N 筆（預設 0，搭配 limit 分頁）
@@ -50,6 +52,10 @@ def register_tools(mcp: FastMCP, client: Optional[TWSEAPIClient] = None) -> None
             return f"查無 {date} 的個股收盤行情資料"
 
         data = stock_table["data"]
+        if stock_no:
+            data = [row for row in data if row[0].strip() == stock_no]
+            if not data:
+                return f"查無股票代號 {stock_no} 在 {date} 的收盤行情"
         if name:
             data = [row for row in data if name in row[1]]
             if not data:

--- a/tools/history/all_stocks_daily_close.py
+++ b/tools/history/all_stocks_daily_close.py
@@ -1,0 +1,80 @@
+"""TWSE all-listed-stocks daily closing quotes (whole-market snapshot, any past date)."""
+
+from typing import Optional
+from fastmcp import FastMCP
+from utils import TWSEAPIClient, handle_api_errors, DEFAULT_DISPLAY_LIMIT
+
+MI_INDEX_URL = "https://www.twse.com.tw/rwd/zh/afterTrading/MI_INDEX"
+
+# The table with per-stock quotes ("每日收盤行情") is a specific entry within the
+# `tables` array MI_INDEX returns (the rest are index-level summary tables). Its
+# position has been stable across dates tested; located by title prefix as a
+# safety net in case TWSE reorders the tables.
+STOCK_TABLE_TITLE_PREFIX = "每日收盤行情"
+
+
+def register_tools(mcp: FastMCP, client: Optional[TWSEAPIClient] = None) -> None:
+    """Register TWSE all-stocks daily close tools."""
+    _client = client or TWSEAPIClient.get_instance()
+
+    @mcp.tool
+    @handle_api_errors()
+    def get_all_stocks_daily_close(date: str, name: str = "", limit: int = DEFAULT_DISPLAY_LIMIT, offset: int = 0) -> str:
+        """查詢指定日期全部上市股票的每日收盤行情（開高低收、成交量、本益比）。
+        與 get_stock_history（單一股票查一整月）互補：此工具是「單一日期查全市場」，
+        適合抓某天的市場快照或篩選特定條件的股票。
+
+        Args:
+            date: 查詢日期，格式 YYYYMMDD，例如 "20260610"（需為交易日）
+            name: 股票名稱關鍵字（選填）
+            limit: 回傳筆數上限（預設 50）
+            offset: 跳過前 N 筆（預設 0，搭配 limit 分頁）
+
+        Returns:
+            每支股票的代號、名稱、成交股數、成交金額、開高低收、漲跌、本益比
+        """
+        resp = _client.fetch_json(
+            MI_INDEX_URL,
+            params={"response": "json", "date": date, "type": "ALLBUT0999"},
+        )
+
+        if not resp or resp.get("stat") != "OK":
+            return f"查無 {date} 的收盤行情資料，請確認該日期為交易日（非假日或週末）"
+
+        tables = resp.get("tables", [])
+        stock_table = next(
+            (t for t in tables if (t.get("title") or "").find(STOCK_TABLE_TITLE_PREFIX) != -1),
+            None,
+        )
+        if not stock_table or not stock_table.get("data"):
+            return f"查無 {date} 的個股收盤行情資料"
+
+        data = stock_table["data"]
+        if name:
+            data = [row for row in data if name in row[1]]
+            if not data:
+                return f"查無名稱包含「{name}」的股票在 {date} 的收盤行情"
+
+        total = len(data)
+        page_data = data[offset:offset + limit]
+        end = min(offset + limit, total)
+
+        header = f"【{date} 全市場每日收盤行情】（共 {total} 筆"
+        if total > limit or offset > 0:
+            header += f"，顯示第 {offset + 1}–{end} 筆"
+        header += "）\n"
+
+        lines = [header]
+        for row in page_data:
+            # row: 證券代號,證券名稱,成交股數,成交筆數,成交金額,開盤價,最高價,最低價,收盤價,漲跌(+/-),漲跌價差,最後揭示買價,最後揭示買量,最後揭示賣價,最後揭示賣量,本益比
+            code, sname, volume, _tx, value, o, h, l, c, _dir, change, _bp, _bv, _ap, _av, pe = row
+            lines.append(
+                f"{code} {sname} | 開:{o} 高:{h} 低:{l} 收:{c} 漲跌:{change} | "
+                f"量:{volume} 金額:{value} | 本益比:{pe}"
+            )
+
+        remaining = total - offset - limit
+        if remaining > 0:
+            lines.append(f"\n...還有 {remaining} 筆，使用 offset={offset + limit} 查看更多")
+
+        return "\n".join(lines)

--- a/tools/history/foreign_holdings_history.py
+++ b/tools/history/foreign_holdings_history.py
@@ -1,0 +1,81 @@
+"""TWSE per-stock foreign/mainland-China (外資及陸資) shareholding ratio history."""
+
+from typing import Optional
+from fastmcp import FastMCP
+from utils import TWSEAPIClient, handle_api_errors, DEFAULT_DISPLAY_LIMIT
+
+MI_QFIIS_URL = "https://www.twse.com.tw/rwd/zh/fund/MI_QFIIS"
+
+
+def register_tools(mcp: FastMCP, client: Optional[TWSEAPIClient] = None) -> None:
+    """Register TWSE foreign holdings history tools."""
+    _client = client or TWSEAPIClient.get_instance()
+
+    @mcp.tool
+    @handle_api_errors()
+    def get_foreign_holdings_history(date: str, stock_no: str = "", name: str = "",
+                                      limit: int = DEFAULT_DISPLAY_LIMIT, offset: int = 0) -> str:
+        """查詢指定日期全部上市股票的外資及陸資持股比率。
+        與 get_foreign_investment_by_industry（產業匯總）、get_top_foreign_holdings（前20名排行）
+        不同：這兩者都只有最新一日、且無法指定個股；此工具可查詢「任意過去日期＋任意個股」的
+        外資持股狀況，適合追蹤外資持股比率隨時間的變化。
+
+        Args:
+            date: 查詢日期，格式 YYYYMMDD，例如 "20260610"（需為交易日）
+            stock_no: 股票代號（選填），指定則只回傳該股票
+            name: 股票名稱關鍵字（選填）
+            limit: 回傳筆數上限（預設 50）
+            offset: 跳過前 N 筆（預設 0，搭配 limit 分頁）
+
+        Returns:
+            每支股票的代號、名稱、發行股數、外資及陸資尚可投資股數/比率、全體外資及陸資持股數/比率
+        """
+        resp = _client.fetch_json(
+            MI_QFIIS_URL,
+            params={"response": "json", "date": date, "selectType": "ALLBUT0999"},
+        )
+
+        if not resp or resp.get("stat") != "OK":
+            return f"查無 {date} 的外資及陸資持股資料，請確認該日期為交易日（非假日或週末）"
+
+        data = resp.get("data", [])
+        if not data:
+            return f"查無 {date} 的外資及陸資持股資料"
+
+        if stock_no:
+            data = [row for row in data if row[0].strip() == stock_no]
+            if not data:
+                return f"查無股票代號 {stock_no} 在 {date} 的外資及陸資持股資料"
+        if name:
+            data = [row for row in data if name in row[1]]
+            if not data:
+                return f"查無名稱包含「{name}」的股票在 {date} 的外資及陸資持股資料"
+
+        total = len(data)
+        page_data = data[offset:offset + limit]
+        end = min(offset + limit, total)
+
+        title = resp.get("title", f"{date} 外資及陸資投資持股統計")
+        header = f"【{title}】（共 {total} 筆"
+        if total > limit or offset > 0:
+            header += f"，顯示第 {offset + 1}–{end} 筆"
+        header += "）\n"
+
+        lines = [header]
+        for row in page_data:
+            # row: 證券代號,證券名稱,國際證券編碼,發行股數,外資及陸資尚可投資股數,
+            #      全體外資及陸資持有股數,外資及陸資尚可投資比率,全體外資及陸資持股比率, ...
+            code, sname = row[0], row[1]
+            issued = row[3]
+            remain_shares, held_shares = row[4], row[5]
+            remain_pct, held_pct = row[6], row[7]
+            lines.append(
+                f"{code} {sname} | 外資持股比率:{held_pct}% | 尚可投資比率:{remain_pct}% | "
+                f"持有股數:{held_shares} | 發行股數:{issued}"
+            )
+
+        remaining = total - offset - limit
+        if remaining > 0:
+            lines.append(f"\n...還有 {remaining} 筆，使用 offset={offset + limit} 查看更多")
+
+        return "\n".join(lines)

--- a/tools/history/institutional_amounts.py
+++ b/tools/history/institutional_amounts.py
@@ -1,0 +1,46 @@
+"""TWSE market-level 三大法人 (institutional investor) buy/sell amount statistics."""
+
+from typing import Optional
+from fastmcp import FastMCP
+from utils import TWSEAPIClient, handle_api_errors
+
+BFI82U_URL = "https://www.twse.com.tw/rwd/zh/fund/BFI82U"
+
+
+def register_tools(mcp: FastMCP, client: Optional[TWSEAPIClient] = None) -> None:
+    """Register TWSE market-level institutional amount tools."""
+    _client = client or TWSEAPIClient.get_instance()
+
+    @mcp.tool
+    @handle_api_errors()
+    def get_market_institutional_amounts_history(date: str, period: str = "day") -> str:
+        """查詢台灣上市市場三大法人（自營商、投信、外資及陸資）買賣金額統計表。
+        與 get_twse_institutional_investors_summary（個股買賣超股數）不同，此工具回傳的是
+        「市場層級」的買賣「金額」總計，適合快速回答「外資今天整體買超/賣超多少」。
+
+        Args:
+            date: 查詢日期，格式 YYYYMMDD，例如 "20260610"（需為交易日）
+            period: 統計區間，"day"（日）、"week"（週）或 "month"（月），預設 "day"
+
+        Returns:
+            自營商（自行買賣/避險）、投信、外資及陸資（含外資自營商）的買進/賣出/買賣差額金額（元），及三大法人合計
+        """
+        resp = _client.fetch_json(
+            BFI82U_URL,
+            params={"response": "json", "dayDate": date, "type": period},
+        )
+
+        if not resp or resp.get("stat") != "OK":
+            return f"查無 {date} 的三大法人買賣金額統計，請確認該日期為交易日（非假日或週末）"
+
+        data = resp.get("data", [])
+        if not data:
+            return f"查無 {date} 的三大法人買賣金額統計"
+
+        title = resp.get("title", f"{date} 三大法人買賣金額統計表")
+        lines = [f"【{title}】\n"]
+        for row in data:
+            name, buy, sell, net = row[0], row[1], row[2], row[3]
+            lines.append(f"{name}：買進 {buy} 元 | 賣出 {sell} 元 | 買賣差額 {net} 元")
+
+        return "\n".join(lines)

--- a/tools/history/institutional_amounts.py
+++ b/tools/history/institutional_amounts.py
@@ -13,21 +13,20 @@ def register_tools(mcp: FastMCP, client: Optional[TWSEAPIClient] = None) -> None
 
     @mcp.tool
     @handle_api_errors()
-    def get_market_institutional_amounts_history(date: str, period: str = "day") -> str:
-        """查詢台灣上市市場三大法人（自營商、投信、外資及陸資）買賣金額統計表。
+    def get_market_institutional_amounts_history(date: str) -> str:
+        """查詢台灣上市市場三大法人（自營商、投信、外資及陸資）買賣金額統計表（單日）。
         與 get_twse_institutional_investors_summary（個股買賣超股數）不同，此工具回傳的是
         「市場層級」的買賣「金額」總計，適合快速回答「外資今天整體買超/賣超多少」。
 
         Args:
             date: 查詢日期，格式 YYYYMMDD，例如 "20260610"（需為交易日）
-            period: 統計區間，"day"（日）、"week"（週）或 "month"（月），預設 "day"
 
         Returns:
             自營商（自行買賣/避險）、投信、外資及陸資（含外資自營商）的買進/賣出/買賣差額金額（元），及三大法人合計
         """
         resp = _client.fetch_json(
             BFI82U_URL,
-            params={"response": "json", "dayDate": date, "type": period},
+            params={"response": "json", "dayDate": date, "type": "day"},
         )
 
         if not resp or resp.get("stat") != "OK":

--- a/tools/history/market_turnover.py
+++ b/tools/history/market_turnover.py
@@ -1,0 +1,49 @@
+"""TWSE daily market turnover history (whole month per call)."""
+
+from typing import Optional
+from fastmcp import FastMCP
+from utils import TWSEAPIClient, handle_api_errors
+
+FMTQIK_URL = "https://www.twse.com.tw/rwd/zh/afterTrading/FMTQIK"
+
+
+def register_tools(mcp: FastMCP, client: Optional[TWSEAPIClient] = None) -> None:
+    """Register TWSE market turnover history tools."""
+    _client = client or TWSEAPIClient.get_instance()
+
+    @mcp.tool
+    @handle_api_errors()
+    def get_market_turnover_history(date: str) -> str:
+        """查詢台灣上市市場每日成交量值與發行量加權股價指數。
+        回傳指定月份每一個交易日的市場成交股數、成交金額、成交筆數、加權指數收盤與漲跌點數。
+        與 get_daily_market_trading_info（openapi 版）不同：openapi 版只回傳最近約 12 個交易日的
+        滾動視窗，無法指定過去月份；此工具可查任意過去月份。
+
+        Args:
+            date: 欲查詢的月份，格式 YYYYMMDD（日期隨意，例如 "20260601" 查 2026 年 6 月整月）
+
+        Returns:
+            該月份每個交易日的成交股數、成交金額、成交筆數、加權指數、漲跌點數
+        """
+        resp = _client.fetch_json(
+            FMTQIK_URL,
+            params={"response": "json", "date": date},
+        )
+
+        if not resp or resp.get("stat") != "OK":
+            return f"查無 {date[:6]} 的市場成交資訊，請確認日期是否有效"
+
+        data = resp.get("data", [])
+        if not data:
+            return f"查無 {date[:6]} 的市場成交資訊"
+
+        title = resp.get("title", f"{date[:6]} 市場成交資訊")
+        lines = [f"【{title}】\n"]
+        for row in data:
+            # row: 日期,成交股數,成交金額,成交筆數,發行量加權股價指數,漲跌點數
+            d, volume, value, tx, index, change = row
+            lines.append(
+                f"{d} | 加權指數:{index}（{change}）| 成交量:{volume} | 成交金額:{value} | 筆數:{tx}"
+            )
+
+        return "\n".join(lines)

--- a/tools/history/taiex_index_history.py
+++ b/tools/history/taiex_index_history.py
@@ -1,0 +1,47 @@
+"""TWSE 發行量加權股價指數 (TAIEX) daily OHLC history (whole month per call)."""
+
+from typing import Optional
+from fastmcp import FastMCP
+from utils import TWSEAPIClient, handle_api_errors
+
+MI_5MINS_HIST_URL = "https://www.twse.com.tw/rwd/zh/TAIEX/MI_5MINS_HIST"
+
+
+def register_tools(mcp: FastMCP, client: Optional[TWSEAPIClient] = None) -> None:
+    """Register TAIEX daily OHLC history tools."""
+    _client = client or TWSEAPIClient.get_instance()
+
+    @mcp.tool
+    @handle_api_errors()
+    def get_taiex_index_history(date: str) -> str:
+        """查詢發行量加權股價指數（大盤）每日開高低收歷史資料。
+        與個股的 get_stock_history 對應，但查的是大盤指數本身，適合大盤走勢/K線分析。
+        與 get_market_historical_index（openapi 版）不同：openapi 版只回傳最近約 12 個交易日的
+        滾動視窗，無法指定過去月份；此工具可查任意過去月份。
+
+        Args:
+            date: 欲查詢的月份，格式 YYYYMMDD（日期隨意，例如 "20260601" 查 2026 年 6 月整月）
+
+        Returns:
+            該月份每個交易日的加權指數開盤、最高、最低、收盤指數
+        """
+        resp = _client.fetch_json(
+            MI_5MINS_HIST_URL,
+            params={"response": "json", "date": date},
+        )
+
+        if not resp or resp.get("stat") != "OK":
+            return f"查無 {date[:6]} 的加權指數歷史資料，請確認日期是否有效"
+
+        data = resp.get("data", [])
+        if not data:
+            return f"查無 {date[:6]} 的加權指數歷史資料"
+
+        title = resp.get("title", f"{date[:6]} 發行量加權股價指數歷史資料")
+        lines = [f"【{title}】\n"]
+        for row in data:
+            # row: 日期,開盤指數,最高指數,最低指數,收盤指數
+            d, o, h, l, c = row
+            lines.append(f"{d} | 開:{o} 高:{h} 低:{l} 收:{c}")
+
+        return "\n".join(lines)


### PR DESCRIPTION
## Summary

TWSE half of the plan in #52 (NEW_TOOLS_PLAN.md Tier 1). All 5 hit `www.twse.com.tw/rwd/*` legacy endpoints — the same family as the existing `get_twse_institutional_investors_summary` (T86) — which accept an arbitrary past date/month, unlike their `openapi.twse.com.tw` counterparts.

Before writing these I checked whether "openapi only gives the latest day" (true for TAIFEX per #49) also holds for TWSE, since two similar-sounding tools already exist. It doesn't — openapi.twse.com.tw actually serves a **rolling ~12-day window**, not just the latest day, but still can't be pointed at an arbitrary past date:
- `get_daily_market_trading_info` (openapi `FMTQIK`) — live-tested, returned exactly the last 12 trading days regardless of params
- `get_market_historical_index` (openapi `indicesReport/MI_5MINS_HIST`) — same rolling ~12-day window

So these 2 new tools genuinely add "pick any past month" capability rather than duplicating existing ones — each docstring explicitly calls out the distinction.

## New tools
- **`get_market_institutional_amounts_history`** — market-level 三大法人 buy/sell amounts (`BFI82U`), any date + day/week/month period. No existing tool covers this at all (existing institutional tools are per-stock share counts, not market-level amounts).
- **`get_all_stocks_daily_close`** — full-market daily OHLC snapshot for a given date (`MI_INDEX`). The per-stock table is 1 of 10 tables this endpoint returns (the other 9 are index summaries) — located by title match (`每日收盤行情`) rather than a hardcoded array index, since table order isn't guaranteed.
- **`get_market_turnover_history`** — daily market turnover + TAIEX close, any month (`FMTQIK`).
- **`get_taiex_index_history`** — TAIEX daily OHLC, any month (`MI_5MINS_HIST`).
- **`get_foreign_holdings_history`** — per-stock 外資及陸資 holding ratio for any date + optional stock filter (`MI_QFIIS`) — distinct from `get_foreign_investment_by_industry` (industry aggregate, latest only) and `get_top_foreign_holdings` (top-20 only, latest only, no per-stock lookup).

## Test plan
- [x] `python -m py_compile` on all new/changed files
- [x] Booted the real `server.py` FastMCP instance and called all 5 tools live through `mcp._tool_manager.call_tool(...)` — verified real output (e.g. TSMC 69.98% foreign holding on 2026-06-10, full June 2026 TAIEX OHLC, etc.)
- [x] Added `tests/e2e/test_history_tier1_api.py` asserting the row shape each tool accesses by index (per the "legacy exchangeReport" test convention) — 5 passed
- [x] Ran the full existing history + institutional e2e suite alongside the new tests — 12 passed, no regressions
- [x] Total tool count went from 163 → 168 as expected