### PR TITLE
feat: add TAIFEX Tier 1 historical-data tools (4 new tools)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ TWStockMCPServer is a Model Context Protocol (MCP) server for Taiwan stock marke
 - **MIS 即時報價** (`mis.twse.com.tw`) — 1 tool: 盤中多股即時報價
 - **TPEx OpenAPI** (`tpex.org.tw/openapi`) — 3 tools: 上櫃日收盤、三大法人、本益比
 - **TAIFEX OpenAPI** (`openapi.taifex.com.tw`) — 16 tools: 三大法人系列、大額交易人部位、每日行情、選擇權分析（Delta/OI增減）、保證金、年月統計
-- **TAIFEX 網站下載** (`www.taifex.com.tw`) — 2 tools: 期貨每日OHLC歷史、三大法人期貨部位歷史（HTML表單下載頁面，非 openapi.taifex.com.tw；後者無任何歷史查詢功能，僅回傳最新一個交易日）
+- **TAIFEX 網站下載** (`www.taifex.com.tw`) — 6 tools: 期貨每日OHLC歷史、三大法人期貨部位歷史、Put/Call Ratio歷史、三大法人選擇權買賣權分計歷史、大額交易人未沖銷部位歷史（無伺服器端契約篩選，本地端過濾）、選擇權每日OHLC歷史（HTML表單下載頁面，非 openapi.taifex.com.tw；後者無任何歷史查詢功能，僅回傳最新一個交易日）
 
 ## Development Commands
 
@@ -58,7 +58,9 @@ tools/
 └── taifex/                   # TAIFEX derivatives: futures_position, put_call_ratio, institutional_general,
                               #   institutional_details, daily_market_report, large_traders_oi,
                               #   options_analytics, margin, trading_statistics, futures_daily_history,
-                              #   institutional_futures_history (latter two scrape www.taifex.com.tw's
+                              #   institutional_futures_history, put_call_ratio_history,
+                              #   options_institutional_history, large_traders_futures_history,
+                              #   options_daily_history (latter six scrape www.taifex.com.tw's
                               #   HTML-form download endpoints for multi-day history; openapi.taifex.com.tw
                               #   has no historical query support — every openapi endpoint returns only
                               #   the latest trading day, confirmed by testing all 135 of its endpoints)

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ uv sync && uv run fastmcp dev server.py
 | [MIS 即時報價](https://mis.twse.com.tw) | 盤中即時多股報價（上市+上櫃） | 1 個 |
 | [TPEx OpenAPI](https://www.tpex.org.tw/openapi) | 櫃買中心 — 上櫃日收盤、三大法人（個股/彙總）、本益比、融資融券、注意/處置股、除權息、零股、指數 | 10 個 |
 | [TAIFEX OpenAPI](https://openapi.taifex.com.tw) | 期交所 — 三大法人系列、大額交易人部位、每日行情、選擇權分析、保證金、年月統計 | 16 個 |
-| [TAIFEX 網站下載](https://www.taifex.com.tw) | 期交所網站歷史資料下載頁面 — 期貨每日OHLC歷史、三大法人期貨部位歷史（openapi.taifex.com.tw 僅提供最新一日，無歷史查詢功能） | 2 個 |
+| [TAIFEX 網站下載](https://www.taifex.com.tw) | 期交所網站歷史資料下載頁面 — 期貨每日OHLC歷史、三大法人期貨部位歷史、Put/Call Ratio歷史、三大法人選擇權買賣權分計歷史、大額交易人未沖銷部位歷史、選擇權每日OHLC歷史（openapi.taifex.com.tw 僅提供最新一日，無歷史查詢功能） | 6 個 |
 
 ## 🤝 參與貢獻
 歡迎PR！

--- a/README_en-us.md
+++ b/README_en-us.md
@@ -120,7 +120,7 @@ uv sync && uv run fastmcp dev server.py
 | [MIS Real-time Quotes](https://mis.twse.com.tw) | Intraday real-time multi-stock quotes (listed + OTC) | 1 |
 | [TPEx OpenAPI](https://www.tpex.org.tw/openapi) | TPEx OTC market — daily close, institutional investors (per-stock/summary), P/E ratio, margin balance, warning/disposal stocks, ex-rights/dividends, odd-lot, index | 10 |
 | [TAIFEX OpenAPI](https://openapi.taifex.com.tw) | TAIFEX derivatives — institutional series, large traders OI, daily market report, options analytics, margin, statistics | 16 |
-| [TAIFEX website downloads](https://www.taifex.com.tw) | TAIFEX's own historical data-download pages — futures daily OHLC history, 三大法人 futures position history (openapi.taifex.com.tw only returns the latest trading day, no historical query support) | 2 |
+| [TAIFEX website downloads](https://www.taifex.com.tw) | TAIFEX's own historical data-download pages — futures daily OHLC history, 三大法人 futures position history, Put/Call Ratio history, 三大法人 options calls/puts history, large-trader futures OI history, options daily OHLC history (openapi.taifex.com.tw only returns the latest trading day, no historical query support) | 6 |
 
 ## 🤝 Contributing
 PRs welcome!

--- a/tests/e2e/test_taifex_history_api.py
+++ b/tests/e2e/test_taifex_history_api.py
@@ -72,3 +72,121 @@ class TestInstitutionalTradersByFuturesHistoryAPI:
             "多空未平倉口數淨額", "多空未平倉契約金額淨額(千元)",
         ]
         assert header == expected, f"欄位順序異動: {header}"
+
+
+class TestPutCallRatioHistoryAPI:
+    """Tool get_put_call_ratio_history 依 index 存取的欄位順序：
+    0=日期 1=賣權成交量 2=買權成交量 3=買賣權成交量比率% 4=賣權未平倉量 5=買權未平倉量 6=買賣權未平倉量比率%
+    """
+
+    def test_hardcoded_column_order(self):
+        rows = _post_csv(
+            "https://www.taifex.com.tw/cht/3/pcRatioDown",
+            {"queryStartDate": "2026/06/01", "queryEndDate": "2026/06/05"},
+        )
+        assert len(rows) > 1, "查無資料，無法驗證欄位順序"
+        header = rows[0]
+        expected = [
+            "日期", "賣權成交量", "買權成交量", "買賣權成交量比率%",
+            "賣權未平倉量", "買權未平倉量", "買賣權未平倉量比率%",
+        ]
+        assert header[:len(expected)] == expected, f"欄位順序異動: {header}"
+
+
+class TestOptionsInstitutionalCallsPutsHistoryAPI:
+    """Tool get_options_institutional_calls_puts_history 依 index 存取的欄位順序：
+    0=日期 1=商品名稱 2=買賣權別 3=身份別 4=買方交易口數 5=買方交易契約金額(千元)
+    6=賣方交易口數 7=賣方交易契約金額(千元) 8=交易口數買賣淨額 9=交易契約金額買賣淨額(千元)
+    10=買方未平倉口數 12=賣方未平倉口數 14=未平倉口數買賣淨額
+    """
+
+    def test_hardcoded_column_order(self):
+        rows = _post_csv(
+            "https://www.taifex.com.tw/cht/3/callsAndPutsDateDown",
+            {"queryStartDate": "2026/06/01", "queryEndDate": "2026/06/03", "commodityId": "TXO"},
+        )
+        assert len(rows) > 1, "查無資料，無法驗證欄位順序"
+        header = rows[0]
+        expected = [
+            "日期", "商品名稱", "買賣權別", "身份別",
+            "買方交易口數", "買方交易契約金額(千元)", "賣方交易口數", "賣方交易契約金額(千元)",
+            "交易口數買賣淨額", "交易契約金額買賣淨額(千元)",
+            "買方未平倉口數", "買方未平倉契約金額(千元)", "賣方未平倉口數", "賣方未平倉契約金額(千元)",
+            "未平倉口數買賣淨額", "未平倉契約金額買賣淨額(千元)",
+        ]
+        assert header == expected, f"欄位順序異動: {header}"
+
+
+class TestLargeTradersFuturesHistoryAPI:
+    """Tool get_large_traders_futures_history 依 index 存取的欄位順序：
+    0=日期 1=商品(契約)（篩選契約用） 3=到期月份(週別) 4=交易人類別
+    5=前五大交易人買方 6=前五大交易人賣方 7=前十大交易人買方 8=前十大交易人賣方 9=全市場未沖銷部位數
+    此端點無伺服器端契約篩選，tool 於本地端以 row[1] 過濾。
+    """
+
+    def test_hardcoded_column_order(self):
+        rows = _post_csv(
+            "https://www.taifex.com.tw/cht/3/largeTraderFutDown",
+            {"queryStartDate": "2026/06/01", "queryEndDate": "2026/06/02"},
+        )
+        assert len(rows) > 1, "查無資料，無法驗證欄位順序"
+        header = rows[0]
+        expected = [
+            "日期", "商品(契約)", "商品名稱(契約名稱)", "到期月份(週別)", "交易人類別",
+            "前五大交易人買方", "前五大交易人賣方", "前十大交易人買方", "前十大交易人賣方",
+            "全市場未沖銷部位數",
+        ]
+        assert header == expected, f"欄位順序異動: {header}"
+
+    def test_no_server_side_contract_filter(self):
+        """確認此端點忽略任何契約篩選參數，回傳全部商品（tool 依賴此行為才會在本地端過濾）。"""
+        rows = _post_csv(
+            "https://www.taifex.com.tw/cht/3/largeTraderFutDown",
+            {"queryStartDate": "2026/06/01", "queryEndDate": "2026/06/01", "contractId": "TX"},
+        )
+        codes = set(r[1].strip() for r in rows[1:] if len(r) > 1)
+        assert len(codes) > 1, "端點行為可能已變更為支援伺服器端契約篩選，tool 邏輯需重新檢視"
+
+
+class TestOptionsDailyHistoryAPI:
+    """Tool get_options_daily_history 依 index 存取的欄位順序：
+    0=交易日期 1=契約 2=到期月份(週別) 3=履約價 4=買賣權 5=開盤價 6=最高價 7=最低價 8=收盤價
+    9=成交量 10=結算價 11=未沖銷契約數 ... 17=交易時段
+    注意：header 列尾端多一個逗號（欄位數比實際資料列多 1），tool 的共用 decode_and_parse_csv()
+    容忍此落差；此測試僅比對已知欄位前綴，不比對完整長度。
+    """
+
+    def test_hardcoded_column_order(self):
+        rows = _post_csv(
+            "https://www.taifex.com.tw/cht/3/optDataDown",
+            {
+                "down_type": "1",
+                "commodity_id": "TXO",
+                "commodity_id2": "",
+                "queryStartDate": "2026/06/01",
+                "queryEndDate": "2026/06/01",
+            },
+        )
+        assert len(rows) > 1, "查無資料，無法驗證欄位順序"
+        header = rows[0]
+        expected = [
+            "交易日期", "契約", "到期月份(週別)", "履約價", "買賣權",
+            "開盤價", "最高價", "最低價", "收盤價", "成交量", "結算價", "未沖銷契約數",
+        ]
+        assert header[:len(expected)] == expected, f"欄位順序異動: {header}"
+        assert header[17] == "交易時段", f"交易時段欄位位置異動: {header}"
+
+    def test_commodity_id_filters_server_side(self):
+        """確認 commodity_id 參數真的在伺服器端篩選（與 largeTraderFutDown 行為不同）。"""
+        rows = _post_csv(
+            "https://www.taifex.com.tw/cht/3/optDataDown",
+            {
+                "down_type": "1",
+                "commodity_id": "TXO",
+                "commodity_id2": "",
+                "queryStartDate": "2026/06/01",
+                "queryEndDate": "2026/06/01",
+            },
+        )
+        contracts = set(r[1].strip() for r in rows[1:] if r and len(r) > 1)
+        assert contracts == {"TXO"}, f"commodity_id 篩選行為可能已變更: {contracts}"

--- a/tools/taifex/futures_daily_history.py
+++ b/tools/taifex/futures_daily_history.py
@@ -43,7 +43,10 @@ def decode_and_parse_csv(body: bytes) -> Optional[Tuple[List[str], List[List[str
         return None
 
     header, data_rows = rows[0], rows[1:]
-    data_rows = [r for r in data_rows if len(r) >= len(header) and r[0].strip()]
+    # Tolerate a 1-column length mismatch: some endpoints (e.g. optDataDown) have a
+    # trailing comma in the header row that isn't present in data rows.
+    min_cols = len(header) - 1
+    data_rows = [r for r in data_rows if len(r) >= min_cols and r[0].strip()]
     if not data_rows:
         return None
 

--- a/tools/taifex/large_traders_futures_history.py
+++ b/tools/taifex/large_traders_futures_history.py
@@ -1,0 +1,88 @@
+"""TAIFEX 大額交易人期貨未沖銷部位 history (multi-day download, client-side filtered by contract)."""
+
+from typing import Optional
+from fastmcp import FastMCP
+from utils import TWSEAPIClient, handle_api_errors
+from .futures_position import TAIFEX_HEADERS
+from .futures_daily_history import parse_yyyymmdd, decode_and_parse_csv
+
+# openapi.taifex.com.tw's get_large_traders_futures_oi only returns the latest trading
+# day. This endpoint (www.taifex.com.tw download page) accepts an arbitrary date range,
+# but — unlike futDataDown/futContractsDateDown — the form has NO contract-code filter
+# field at all (confirmed by inspecting the live form and its submit handler): every
+# call returns ALL ~340 commodities for the requested dates (~1,100 rows/day), so
+# filtering to one contract must happen client-side after the fetch. Because the raw
+# payload size doesn't shrink with a narrower contract, span is capped tightly here.
+LARGE_TRADER_FUT_DOWN_URL = "https://www.taifex.com.tw/cht/3/largeTraderFutDown"
+
+MAX_SPAN_DAYS = 31
+
+
+def register_tools(mcp: FastMCP, client: Optional[TWSEAPIClient] = None) -> None:
+    """Register TAIFEX large-trader futures OI history tools."""
+    _client = client or TWSEAPIClient.get_instance()
+
+    @mcp.tool
+    @handle_api_errors()
+    def get_large_traders_futures_history(start_date: str, end_date: str, contract: str) -> str:
+        """查詢期貨大額交易人未沖銷部位歷史資料（可回溯查詢，非僅最新一日）。
+        與 get_large_traders_futures_oi（openapi 版，僅能查最新一個交易日）不同，此工具可
+        查詢任意過去起訖日期。來源端點本身不支援依契約篩選（一次回傳全部約340種商品），
+        故 contract 為必填參數，由本工具在取得資料後於本地端篩選。
+
+        Args:
+            start_date: 起始日期，格式 YYYYMMDD，例如 "20260601"
+            end_date: 結束日期，格式 YYYYMMDD。與 start_date 區間不可超過一個月
+            contract: 期貨契約代碼（必填），例如 "TX"（臺股期貨）、"MTX"（小型臺指）、
+                "TE"（電子期貨）、"TF"（金融期貨）
+
+        Returns:
+            區間內每個交易日，該契約各到期月份的前五大／前十大交易人買方、賣方部位數與全市場未沖銷部位數
+        """
+        try:
+            start_dt = parse_yyyymmdd(start_date)
+            end_dt = parse_yyyymmdd(end_date)
+        except ValueError:
+            return f"日期格式錯誤，請使用 YYYYMMDD 格式（例如 20260601），收到：start_date={start_date}, end_date={end_date}"
+
+        if start_dt > end_dt:
+            return f"起始日期 {start_date} 不可晚於結束日期 {end_date}"
+        if (end_dt - start_dt).days > MAX_SPAN_DAYS:
+            return f"查詢區間不可超過一個月（收到 {(end_dt - start_dt).days} 天），請縮小 start_date～end_date 範圍後重試"
+        if not contract or not contract.strip():
+            return "contract 為必填參數，請指定期貨契約代碼（例如 TX、MTX、TE、TF）"
+
+        contract = contract.strip().upper()
+        body = _client.fetch_bytes(
+            LARGE_TRADER_FUT_DOWN_URL,
+            method="POST",
+            headers=TAIFEX_HEADERS,
+            data={
+                "queryStartDate": start_dt.strftime("%Y/%m/%d"),
+                "queryEndDate": end_dt.strftime("%Y/%m/%d"),
+            },
+        )
+        parsed = decode_and_parse_csv(body)
+        if parsed is None:
+            return f"查無 {start_date}～{end_date} 的大額交易人未沖銷部位資料，日期區間可能無效或超出範圍"
+
+        _header, data_rows = parsed
+        data_rows = [r for r in data_rows if r[1].strip() == contract]
+        if not data_rows:
+            return f"查無契約 {contract} 在 {start_date}～{end_date} 的大額交易人未沖銷部位資料，請確認契約代碼是否正確"
+
+        lines = [
+            f"【期貨大額交易人未沖銷部位歷史】契約:{contract} 區間:{start_date}~{end_date}（共 {len(data_rows)} 筆）\n"
+        ]
+        for r in data_rows:
+            date, month, category = r[0], r[3].strip(), r[4]
+            top5_buy, top5_sell = r[5], r[6]
+            top10_buy, top10_sell = r[7], r[8]
+            market_oi = r[9]
+            lines.append(
+                f"{date} | {month} | 類別:{category} | "
+                f"前五大: 買 {top5_buy} / 賣 {top5_sell} | 前十大: 買 {top10_buy} / 賣 {top10_sell} | "
+                f"全市場未平倉: {market_oi}"
+            )
+
+        return "\n".join(lines)

--- a/tools/taifex/options_daily_history.py
+++ b/tools/taifex/options_daily_history.py
@@ -1,0 +1,108 @@
+"""TAIFEX 選擇權每日OHLC歷史行情 history (multi-day download, not exposed via openapi.taifex.com.tw)."""
+
+from typing import Optional
+from fastmcp import FastMCP
+from utils import TWSEAPIClient, handle_api_errors
+from .futures_position import TAIFEX_HEADERS
+from .futures_daily_history import parse_yyyymmdd, decode_and_parse_csv
+
+# openapi.taifex.com.tw's DailyMarketReportOpt (get_daily_options_market_report) only
+# returns the latest trading day. This endpoint (www.taifex.com.tw download page)
+# accepts an arbitrary date range up to ~1 month (server-enforced, same as futDataDown).
+# `commodity_id` DOES filter server-side (confirmed live: TXO-only request returns only
+# TXO rows) — but even a single day for TXO alone is ~6,400 rows across all strikes and
+# ~9 contract months, so a multi-day pull without a contract_month filter would be far
+# too large for tool output. If contract_month is omitted and the result is large, the
+# available months are listed instead of dumping everything (same UX as get_options_delta).
+OPT_DATA_DOWN_URL = "https://www.taifex.com.tw/cht/3/optDataDown"
+
+MAX_SPAN_DAYS = 31
+ROW_LIMIT_WITHOUT_MONTH_FILTER = 300
+
+
+def register_tools(mcp: FastMCP, client: Optional[TWSEAPIClient] = None) -> None:
+    """Register TAIFEX options daily OHLC history tools."""
+    _client = client or TWSEAPIClient.get_instance()
+
+    @mcp.tool
+    @handle_api_errors()
+    def get_options_daily_history(start_date: str, end_date: str, contract: str = "TXO",
+                                   contract_month: str = "", call_put: str = "") -> str:
+        """查詢選擇權每日OHLC歷史行情（可回溯查詢，非僅最新一日）。
+        與 get_daily_options_market_report（openapi 版，僅能查最新一個交易日）不同，此工具
+        可查詢任意過去起訖日期。因資料量龐大（單日單契約逾6000筆，涵蓋全部履約價與到期月份），
+        強烈建議指定 contract_month 縮小範圍；若未指定且資料量過大，會改為列出可用到期月份。
+
+        Args:
+            start_date: 起始日期，格式 YYYYMMDD，例如 "20260601"
+            end_date: 結束日期，格式 YYYYMMDD。與 start_date 區間不可超過一個月
+            contract: 選擇權契約代碼，預設 TXO（臺指選擇權）。其他常用：TEO（電子選擇權）、
+                TFO（金融選擇權）
+            contract_month: 到期月份/週次，例如「202606」或「202606W1」。留空且資料量過大時，
+                會回傳可用到期月份清單供選擇
+            call_put: 篩選「買權」或「賣權」，留空則顯示全部
+
+        Returns:
+            區間內每個交易日、指定到期月份各履約價的開高低收、成交量、結算價、未沖銷契約數
+        """
+        try:
+            start_dt = parse_yyyymmdd(start_date)
+            end_dt = parse_yyyymmdd(end_date)
+        except ValueError:
+            return f"日期格式錯誤，請使用 YYYYMMDD 格式（例如 20260601），收到：start_date={start_date}, end_date={end_date}"
+
+        if start_dt > end_dt:
+            return f"起始日期 {start_date} 不可晚於結束日期 {end_date}"
+        if (end_dt - start_dt).days > MAX_SPAN_DAYS:
+            return f"查詢區間不可超過一個月（收到 {(end_dt - start_dt).days} 天），請縮小 start_date～end_date 範圍後重試"
+
+        contract = contract.strip().upper()
+        body = _client.fetch_bytes(
+            OPT_DATA_DOWN_URL,
+            method="POST",
+            headers=TAIFEX_HEADERS,
+            data={
+                "down_type": "1",
+                "commodity_id": contract,
+                "commodity_id2": "",
+                "queryStartDate": start_dt.strftime("%Y/%m/%d"),
+                "queryEndDate": end_dt.strftime("%Y/%m/%d"),
+            },
+        )
+        parsed = decode_and_parse_csv(body)
+        if parsed is None:
+            return f"查無契約 {contract} 在 {start_date}～{end_date} 的選擇權行情資料，請確認契約代碼是否正確"
+
+        _header, data_rows = parsed
+
+        if contract_month:
+            data_rows = [r for r in data_rows if r[2].strip() == contract_month]
+        if call_put:
+            data_rows = [r for r in data_rows if r[4] == call_put]
+
+        if not contract_month and len(data_rows) > ROW_LIMIT_WITHOUT_MONTH_FILTER:
+            months = sorted(set(r[2].strip() for r in data_rows))
+            return (
+                f"契約 {contract} 在 {start_date}～{end_date} 共有 {len(data_rows)} 筆資料，"
+                f"資料量過大無法完整顯示。可用到期月份（共 {len(months)} 個）：\n"
+                + "、".join(months)
+                + "\n請指定 contract_month 參數以縮小查詢範圍。"
+            )
+
+        if not data_rows:
+            return f"查無契約 {contract} 在 {start_date}～{end_date}（到期月份:{contract_month or '全部'}）的選擇權行情資料"
+
+        lines = [
+            f"【選擇權每日OHLC歷史行情】契約:{contract} 到期月份:{contract_month or '全部'} "
+            f"區間:{start_date}~{end_date}（共 {len(data_rows)} 筆）\n"
+        ]
+        for r in data_rows:
+            date, month, strike, cp = r[0], r[2].strip(), r[3], r[4]
+            o, h, l, c = r[5], r[6], r[7], r[8]
+            vol, settle, oi, session = r[9], r[10], r[11], r[17]
+            lines.append(
+                f"{date} | {month} | 履約價:{strike} {cp} | {session} | "
+                f"開:{o} 高:{h} 低:{l} 收:{c} | 量:{vol} | 結算:{settle} | 未平倉:{oi}"
+            )
+
+        return "\n".join(lines)

--- a/tools/taifex/options_institutional_history.py
+++ b/tools/taifex/options_institutional_history.py
@@ -1,0 +1,83 @@
+"""TAIFEX 三大法人選擇權 CALL/PUT 分計 history (multi-day download)."""
+
+from typing import Optional
+from fastmcp import FastMCP
+from utils import TWSEAPIClient, handle_api_errors
+from .futures_position import TAIFEX_HEADERS
+from .futures_daily_history import parse_yyyymmdd, decode_and_parse_csv
+
+# openapi.taifex.com.tw's get_institutional_traders_calls_puts only returns the latest
+# trading day. This endpoint (www.taifex.com.tw download page) accepts an arbitrary date
+# range. No server-enforced span cap observed (tested a clean 90-day pull), but capped
+# client-side to keep tool output manageable. Retention verified back to roughly 2023H2.
+CALLS_AND_PUTS_DATE_DOWN_URL = "https://www.taifex.com.tw/cht/3/callsAndPutsDateDown"
+
+MAX_SPAN_DAYS = 92
+
+
+def register_tools(mcp: FastMCP, client: Optional[TWSEAPIClient] = None) -> None:
+    """Register TAIFEX institutional options calls/puts history tools."""
+    _client = client or TWSEAPIClient.get_instance()
+
+    @mcp.tool
+    @handle_api_errors()
+    def get_options_institutional_calls_puts_history(start_date: str, end_date: str, contract: str = "TXO") -> str:
+        """查詢三大法人選擇權買賣權（CALL/PUT）分計交易歷史（可回溯查詢，非僅最新一日）。
+        與 get_institutional_traders_calls_puts（openapi 版，僅能查最新一個交易日）不同，
+        此工具可查詢任意過去起訖日期，適合觀察外資對選擇權 CALL/PUT 布局隨時間的變化趨勢。
+
+        Args:
+            start_date: 起始日期，格式 YYYYMMDD，例如 "20260401"
+            end_date: 結束日期，格式 YYYYMMDD。與 start_date 區間不可超過 92 天
+            contract: 選擇權契約代碼，預設 TXO（臺指選擇權）。其他常用：TEO（電子選擇權）、
+                TFO（金融選擇權）
+
+        Returns:
+            區間內每個交易日、每個身份別（自營商/投信/外資）在 CALL/PUT 的買賣口數、契約金額、未平倉資訊
+        """
+        try:
+            start_dt = parse_yyyymmdd(start_date)
+            end_dt = parse_yyyymmdd(end_date)
+        except ValueError:
+            return f"日期格式錯誤，請使用 YYYYMMDD 格式（例如 20260401），收到：start_date={start_date}, end_date={end_date}"
+
+        if start_dt > end_dt:
+            return f"起始日期 {start_date} 不可晚於結束日期 {end_date}"
+        if (end_dt - start_dt).days > MAX_SPAN_DAYS:
+            return f"查詢區間不可超過 {MAX_SPAN_DAYS} 天（收到 {(end_dt - start_dt).days} 天），請縮小 start_date～end_date 範圍後重試"
+
+        contract = contract.strip().upper()
+        body = _client.fetch_bytes(
+            CALLS_AND_PUTS_DATE_DOWN_URL,
+            method="POST",
+            headers=TAIFEX_HEADERS,
+            data={
+                "queryStartDate": start_dt.strftime("%Y/%m/%d"),
+                "queryEndDate": end_dt.strftime("%Y/%m/%d"),
+                "commodityId": contract,
+            },
+        )
+        parsed = decode_and_parse_csv(body)
+        if parsed is None:
+            return (
+                f"查無契約 {contract} 在 {start_date}～{end_date} 的三大法人買賣權分計資料，"
+                f"請確認契約代碼是否正確；日期區間也可能超出資料保存範圍（約近 3 年內）"
+            )
+
+        _header, data_rows = parsed
+        lines = [
+            f"【三大法人選擇權買賣權分計歷史】契約:{contract} 區間:{start_date}~{end_date}（共 {len(data_rows)} 筆）\n"
+        ]
+        for r in data_rows:
+            date, name, cp, identity = r[0], r[1], r[2], r[3]
+            buy_vol, buy_amt = r[4], r[5]
+            sell_vol, sell_amt = r[6], r[7]
+            net_vol, net_amt = r[8], r[9]
+            oi_buy, oi_sell, oi_net = r[10], r[12], r[14]
+            lines.append(
+                f"{date} | {name} {cp} | {identity}\n"
+                f"  交易: 買 {buy_vol}({buy_amt}千元) / 賣 {sell_vol}({sell_amt}千元) / 淨 {net_vol}({net_amt}千元)\n"
+                f"  未平倉: 買 {oi_buy} / 賣 {oi_sell} / 淨 {oi_net}"
+            )
+
+        return "\n".join(lines)

--- a/tools/taifex/put_call_ratio_history.py
+++ b/tools/taifex/put_call_ratio_history.py
@@ -1,0 +1,69 @@
+"""TAIFEX 台指選擇權 Put/Call Ratio history (multi-day download, not exposed via openapi.taifex.com.tw)."""
+
+from typing import Optional
+from fastmcp import FastMCP
+from utils import TWSEAPIClient, handle_api_errors
+from .futures_position import TAIFEX_HEADERS
+from .futures_daily_history import parse_yyyymmdd, decode_and_parse_csv
+
+# openapi.taifex.com.tw's PutCallRatio endpoint (get_put_call_ratio) already returns a
+# rolling ~21-trading-day window with no date param. This endpoint (www.taifex.com.tw's
+# download page) genuinely accepts an arbitrary start/end date, useful for pulling a
+# specific past period rather than only "recent". Server-enforced max span: 30 calendar days.
+PC_RATIO_DOWN_URL = "https://www.taifex.com.tw/cht/3/pcRatioDown"
+
+MAX_SPAN_DAYS = 30
+
+
+def register_tools(mcp: FastMCP, client: Optional[TWSEAPIClient] = None) -> None:
+    """Register TAIFEX Put/Call Ratio history tools."""
+    _client = client or TWSEAPIClient.get_instance()
+
+    @mcp.tool
+    @handle_api_errors()
+    def get_put_call_ratio_history(start_date: str, end_date: str) -> str:
+        """查詢台指選擇權 Put/Call Ratio 歷史資料（可指定任意起訖區間，非僅近期滾動窗口）。
+        與 get_put_call_ratio（openapi 版，固定回傳近 21 個交易日）不同，此工具可指定任意
+        過去起訖日期，適合回溯特定歷史期間的市場多空氣氛。
+
+        Args:
+            start_date: 起始日期，格式 YYYYMMDD，例如 "20260501"
+            end_date: 結束日期，格式 YYYYMMDD。與 start_date 區間不可超過 30 天
+
+        Returns:
+            區間內每個交易日的賣權/買權成交量、買賣權成交量比率%、賣權/買權未平倉量、買賣權未平倉量比率%
+        """
+        try:
+            start_dt = parse_yyyymmdd(start_date)
+            end_dt = parse_yyyymmdd(end_date)
+        except ValueError:
+            return f"日期格式錯誤，請使用 YYYYMMDD 格式（例如 20260501），收到：start_date={start_date}, end_date={end_date}"
+
+        if start_dt > end_dt:
+            return f"起始日期 {start_date} 不可晚於結束日期 {end_date}"
+        if (end_dt - start_dt).days > MAX_SPAN_DAYS:
+            return f"查詢區間不可超過 {MAX_SPAN_DAYS} 天（收到 {(end_dt - start_dt).days} 天），請縮小 start_date～end_date 範圍後重試"
+
+        body = _client.fetch_bytes(
+            PC_RATIO_DOWN_URL,
+            method="POST",
+            headers=TAIFEX_HEADERS,
+            data={
+                "queryStartDate": start_dt.strftime("%Y/%m/%d"),
+                "queryEndDate": end_dt.strftime("%Y/%m/%d"),
+            },
+        )
+        parsed = decode_and_parse_csv(body)
+        if parsed is None:
+            return f"查無 {start_date}～{end_date} 的 Put/Call Ratio 資料，日期區間可能無效或超出範圍"
+
+        _header, data_rows = parsed
+        lines = [f"【台指選擇權 Put/Call Ratio 歷史】區間:{start_date}~{end_date}（共 {len(data_rows)} 筆）\n"]
+        for r in data_rows:
+            date, put_vol, call_vol, pcr_vol, put_oi, call_oi, pcr_oi = r[0], r[1], r[2], r[3], r[4], r[5], r[6]
+            lines.append(
+                f"{date} | 成交量 PCR:{pcr_vol}%（Put:{put_vol} Call:{call_vol}） | "
+                f"未平倉 PCR:{pcr_oi}%（Put:{put_oi} Call:{call_oi}）"
+            )
+
+        return "\n".join(lines)


### PR DESCRIPTION
## Summary

TAIFEX half of the plan in #52 (NEW_TOOLS_PLAN.md Tier 1), completing #53's TWSE half. All 4 hit `www.taifex.com.tw/cht/3/*Down` HTML-form download endpoints — same family as #49's `get_futures_daily_history`/`get_institutional_traders_by_futures_history` — which accept arbitrary date ranges, unlike their `openapi.taifex.com.tw` counterparts (latest-day-only, established in #49).

## New tools
- **`get_put_call_ratio_history`** — arbitrary-range P/C ratio (`pcRatioDown`). Binary-searched the server's actual max span: **30 calendar days** (a hard cutoff, stricter than `futDataDown`'s ~1 month).
- **`get_options_institutional_calls_puts_history`** — 三大法人 CALL/PUT positions over time (`callsAndPutsDateDown`). No span cap observed up to 90 days (capped client-side at 92 anyway). Retention boundary narrowed to between 2023/06 (fails) and 2023/09 (works) — matches #49's institutional-history cutoff.
- **`get_large_traders_futures_history`** — large-trader futures OI history (`largeTraderFutDown`). Inspected the live form and its actual submit handler (not just the static HTML) and found **no contract-filter field exists at all** — every call returns ~1,100 rows/day across ~340 commodities. `contract` is therefore a required param, filtered client-side after the fetch; span capped at 31 days since the raw payload size doesn't shrink with a narrower contract.
- **`get_options_daily_history`** — options daily OHLC history (`optDataDown`). Unlike the tool above, `commodity_id` **does** filter server-side (verified: a TXO-only request returns only TXO rows). But a single day for TXO alone is already ~6,400 rows across ~9 contract months, so when `contract_month` is omitted and the result would be too large, the tool lists available months instead of dumping everything — same UX as the existing `get_options_delta`.

## Bug found and fixed while building these
`decode_and_parse_csv()` (the shared helper in `futures_daily_history.py` all 6 www.taifex.com.tw-scraping tools now use) required data rows to have `>= len(header)` columns. `optDataDown`'s header row has a trailing comma that the data rows don't — so every row was silently filtered out, and the tool returned "no data" even when the raw response had real content. Caught by fetching the raw response bytes directly and comparing against what `decode_and_parse_csv` returned (592KB body → 0 parsed rows). Relaxed the check to tolerate a 1-column shortfall; re-verified all 6 tools (4 new + 2 from #53) still work correctly after the change — no regression.

## Unrelated finding (not fixed in this PR)
While running the full TAIFEX test suite for regressions, `tests/e2e/test_taifex_new_api.py::TestLargeTradersOIFuturesAPI` errored — `openapi.taifex.com.tw`'s `OpenInterestOfLargeTradersFutures` endpoint (backing the existing `get_large_traders_futures_oi` tool) is currently returning **CSV instead of JSON**. Confirmed via direct `curl` with the correct `Accept: application/json` header — genuine upstream behavior change, not caused by anything touched in this PR (`git diff` against `main` for that tool/test file is empty). Flagging for separate follow-up rather than scope-creeping this PR.

## Test plan
- [x] `python -m py_compile` on all new/changed files
- [x] Booted the real `server.py` FastMCP instance and called all 4 new tools live through `mcp._tool_manager.call_tool(...)` — verified real multi-day output, plus edge cases (missing required `contract`, no `contract_month` triggering the available-months fallback)
- [x] Added 6 test classes to `tests/e2e/test_taifex_history_api.py` (4 for the new tools + `commodity_id`/no-contract-filter behavior pins) — all pass
- [x] Re-ran the full TAIFEX e2e suite for regressions — 33 passed (the 2 errors are the unrelated upstream issue above, confirmed by clean `git diff` on the affected files)
- [x] Total tool count: 168 → 172 as expected