### PR TITLE
fix: tolerate CSV response from OpenInterestOfLargeTradersFutures

### DIFF
--- a/tests/e2e/test_taifex_new_api.py
+++ b/tests/e2e/test_taifex_new_api.py
@@ -69,9 +69,41 @@ class TestDailyOptionsMarketReportAPI:
         assert any(x.get("Contract") == "TXO" for x in daily_market_report_opt)
 
 
+def _fetch_large_traders_oi_futures() -> list:
+    """OpenInterestOfLargeTradersFutures started returning CSV instead of JSON as of
+    2026-07 (confirmed genuine upstream regression, not a header/format issue on our
+    side — the sibling Options endpoint is unaffected). Tool get_large_traders_futures_oi
+    tolerates this via a JSON-with-CSV-fallback helper; mirror that here so this test
+    keeps validating the fields the tool actually depends on regardless of which format
+    the API happens to be serving.
+    """
+    resp = requests.get(
+        "https://openapi.taifex.com.tw/v1/OpenInterestOfLargeTradersFutures",
+        headers=HEADERS, verify=False, timeout=15,
+    )
+    try:
+        return resp.json()
+    except requests.exceptions.JSONDecodeError:
+        pass
+
+    import csv
+    import io
+
+    header_map = {
+        "日期": "Date", "契約": "Contract", "商品名稱(契約名稱)": "ContractName",
+        "到期月份(週別)": "SettlementMonth", "交易人類別": "TypeOfTraders",
+        "前五大交易人買方數量": "Top5Buy", "前五大交易人賣方數量": "Top5Sell",
+        "前十大交易人買方數量": "Top10Buy", "前十大交易人賣方數量": "Top10Sell",
+        "全市場未沖銷部位數": "OIOfMarket",
+    }
+    rows = list(csv.reader(io.StringIO(resp.content.decode("utf-8-sig", errors="replace"))))
+    header = [header_map.get(h.strip(), h.strip()) for h in rows[0]]
+    return [dict(zip(header, r)) for r in rows[1:] if r and r[0].strip()]
+
+
 @pytest.fixture(scope="class")
 def large_traders_oi_futures():
-    return _fetch("OpenInterestOfLargeTradersFutures")
+    return _fetch_large_traders_oi_futures()
 
 
 class TestLargeTradersOIFuturesAPI:

--- a/tools/taifex/large_traders_oi.py
+++ b/tools/taifex/large_traders_oi.py
@@ -1,6 +1,9 @@
 """TAIFEX large traders open interest data."""
 
-from typing import Optional
+import csv
+import io
+import json
+from typing import Any, Dict, List, Optional
 from fastmcp import FastMCP
 from utils import TWSEAPIClient, handle_api_errors
 from .futures_position import TAIFEX_HEADERS
@@ -10,6 +13,42 @@ TAIFEX_LT_OPT_URL = "https://openapi.taifex.com.tw/v1/OpenInterestOfLargeTraders
 
 _TYPE_LABELS = {"0": "所有交易人", "1": "特定法人"}
 _SETTLE_LABELS = {"666666": "所有月份合計", "999912": "所有月份總計"}
+
+# As of 2026-07, OpenInterestOfLargeTradersFutures started returning CSV instead of the
+# documented JSON (confirmed via curl with an explicit Accept: application/json header —
+# a genuine upstream regression, not a request-formatting issue on our side). The sibling
+# OpenInterestOfLargeTradersOptions endpoint is unaffected. Map CSV header text (Chinese)
+# to the JSON field names the rest of this module already expects, so a future reversal
+# back to JSON needs no further changes here.
+_CSV_HEADER_TO_FIELD = {
+    "日期": "Date",
+    "契約": "Contract",
+    "商品名稱(契約名稱)": "ContractName",
+    "到期月份(週別)": "SettlementMonth",
+    "交易人類別": "TypeOfTraders",
+    "前五大交易人買方數量": "Top5Buy",
+    "前五大交易人賣方數量": "Top5Sell",
+    "前十大交易人買方數量": "Top10Buy",
+    "前十大交易人賣方數量": "Top10Sell",
+    "全市場未沖銷部位數": "OIOfMarket",
+}
+
+
+def _fetch_json_with_csv_fallback(client: TWSEAPIClient, url: str, headers: Dict[str, str]) -> List[Dict[str, Any]]:
+    """Fetch a TAIFEX OpenAPI list endpoint, tolerating a CSV response where JSON is expected."""
+    body = client.fetch_bytes(url, headers=headers)
+    try:
+        return json.loads(body)
+    except json.JSONDecodeError:
+        pass
+
+    text = body.decode("utf-8-sig", errors="replace")
+    rows = list(csv.reader(io.StringIO(text)))
+    if len(rows) < 2:
+        return []
+
+    header = [_CSV_HEADER_TO_FIELD.get(h.strip(), h.strip()) for h in rows[0]]
+    return [dict(zip(header, row)) for row in rows[1:] if row and row[0].strip()]
 
 
 def register_tools(mcp: FastMCP, client: Optional[TWSEAPIClient] = None) -> None:
@@ -28,7 +67,7 @@ def register_tools(mcp: FastMCP, client: Optional[TWSEAPIClient] = None) -> None
         Returns:
             前五大／前十大交易人的多空部位及市場總未平倉，區分所有交易人與特定法人
         """
-        data = _client.fetch_json(TAIFEX_LT_FUT_URL, headers=TAIFEX_HEADERS)
+        data = _fetch_json_with_csv_fallback(_client, TAIFEX_LT_FUT_URL, TAIFEX_HEADERS)
 
         if not isinstance(data, list) or not data:
             return "查無期貨大額交易人未沖銷部位資料"


### PR DESCRIPTION
## Summary

As of 2026-07, `openapi.taifex.com.tw`'s `OpenInterestOfLargeTradersFutures` endpoint started returning **CSV instead of its documented JSON** — genuine upstream regression, confirmed via direct `curl` with an explicit `Accept: application/json` header (made no difference), and confirmed isolated to this one endpoint (the sibling `OpenInterestOfLargeTradersOptions` is still fine JSON, verified live). This broke `get_large_traders_futures_oi` (`fetch_json` raises `JSONDecodeError`) and `tests/e2e/test_taifex_new_api.py::TestLargeTradersOIFuturesAPI` — surfaced while regression-testing #54, but confirmed unrelated to anything in that PR (`git diff` against `main` for this file was empty before this change).

## Fix

Added `_fetch_json_with_csv_fallback()` in `large_traders_oi.py`: try JSON first, and on failure decode the response as CSV, mapping the Chinese header text to the same JSON field names (`Date`, `Contract`, `ContractName`, `SettlementMonth`, `TypeOfTraders`, `Top5Buy`, `Top5Sell`, `Top10Buy`, `Top10Sell`, `OIOfMarket`) the rest of the tool already expects — so the tool's filtering/formatting logic needed **zero** changes, and if TAIFEX reverts to JSON later this keeps working with no further changes needed either.

Scoped narrowly to the one confirmed-broken endpoint (`get_large_traders_futures_oi`) — the still-working `get_large_traders_options_oi` sibling is untouched.

Mirrored the same fallback in the test file's fixture (`_fetch_large_traders_oi_futures`) so `test_hardcoded_fields_exist` keeps validating the fields the tool actually depends on regardless of which format the API happens to be serving today.

## Test plan
- [x] `python -m py_compile tools/taifex/large_traders_oi.py`
- [x] Booted the real `server.py` FastMCP instance and called `get_large_traders_futures_oi` live (both with `contract="TX"` and with no contract, listing all 341 available codes) — verified real output, correctly parsed from the CSV response
- [x] Called `get_large_traders_options_oi` live to confirm the untouched sibling still works normally (JSON path, unaffected)
- [x] `tests/e2e/test_taifex_new_api.py` — 15 passed (previously 2 errored)
- [x] Full TAIFEX e2e suite (`test_taifex_api.py` + `test_taifex_batch2_api.py` + `test_taifex_new_api.py` + `test_taifex_history_api.py`) — 35 passed, no regressions