### PR TITLE
feat: add TWSE Tier 2 historical-data tools (5 new tools)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 TWStockMCPServer is a Model Context Protocol (MCP) server for Taiwan stock market data analysis. Built with FastMCP (Python) and `requests`. Data sources:
 - **TWSE OpenAPI** (`openapi.twse.com.tw`) — 143 tools: 公司治理、ESG、財報、交易、指數、券商
-- **TWSE Web API** (`twse.com.tw`) — 11 tools: 歷史日K、月均價、估值、融資融券（`/exchangeReport`）；三大法人買賣超日報、個股明細（`/rwd/zh/fund/T86`）；三大法人買賣金額、全市場收盤行情、市場成交量值、加權指數歷史、外資持股歷史（`/rwd/zh/...`，可查任意過去日期，與同名 openapi.twse.com.tw 端點僅回傳最近約12個交易日不同）（legacy JSON，非 Swagger）
+- **TWSE Web API** (`twse.com.tw`) — 16 tools: 歷史日K、月均價、估值、融資融券（`/exchangeReport`）；三大法人買賣超日報、個股明細（`/rwd/zh/fund/T86`）；三大法人買賣金額、全市場收盤行情、市場成交量值、加權指數歷史、外資持股歷史（`/rwd/zh/...`，可查任意過去日期，與同名 openapi.twse.com.tw 端點僅回傳最近約12個交易日不同）；個股月/年成交彙總、鉅額交易明細（無伺服器端股票篩選，本地端過濾）、融券借券餘額/成交（`/rwd/zh/...`）（legacy JSON，非 Swagger）
 - **MIS 即時報價** (`mis.twse.com.tw`) — 1 tool: 盤中多股即時報價
 - **TPEx OpenAPI** (`tpex.org.tw/openapi`) — 3 tools: 上櫃日收盤、三大法人、本益比
 - **TAIFEX OpenAPI** (`openapi.taifex.com.tw`) — 16 tools: 三大法人系列、大額交易人部位、每日行情、選擇權分析（Delta/OI增減）、保證金、年月統計
@@ -51,7 +51,8 @@ tools/
 ├── market/                   # Market tools: indices, statistics, foreign
 ├── history/                  # TWSE legacy: stock_day, stock_day_avg, bwibbu_all, margin_balance (exchangeReport); institutional (T86);
                               #   institutional_amounts, all_stocks_daily_close, market_turnover, taiex_index_history,
-                              #   foreign_holdings_history (rwd/* endpoints — accept arbitrary past dates, unlike the
+                              #   foreign_holdings_history, stock_monthly_yearly_history, block_trades_detail,
+                              #   short_sale_lending (rwd/* endpoints — accept arbitrary past dates, unlike the
                               #   openapi.twse.com.tw equivalents which only return a rolling ~12-day window)
 ├── realtime/                 # MIS real-time quotes: stock_info
 ├── otc/                      # TPEx OTC market: daily_close, institutional, peratio

--- a/NEW_TOOLS_PLAN.md
+++ b/NEW_TOOLS_PLAN.md
@@ -53,6 +53,6 @@
 
 ## 進度
 
-- [ ] PR-A：TWSE Tier 1（#1–#5）
-- [ ] PR-B：TAIFEX Tier 1（#6–#9）
+- [x] PR-A：TWSE Tier 1（#1–#5）— #53
+- [x] PR-B：TAIFEX Tier 1（#6–#9）— #54
 - [ ] PR-C：Tier 2（#10–#15）

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ uv sync && uv run fastmcp dev server.py
 | 來源 | 說明 | Tools |
 |------|------|-------|
 | [TWSE OpenAPI](https://openapi.twse.com.tw) | 台灣證交所官方 API — 公司治理、ESG、財報、交易、指數等 | 143 個 |
-| [TWSE Web API](https://www.twse.com.tw) | 證交所網頁 API — 個股日K、月均價、估值、融資融券、上市三大法人買賣超（金額/股數）、全市場收盤行情、加權指數歷史、外資持股歷史 | 11 個 |
+| [TWSE Web API](https://www.twse.com.tw) | 證交所網頁 API — 個股日K、月均價、估值、融資融券、上市三大法人買賣超（金額/股數）、全市場收盤行情、加權指數歷史、外資持股歷史、個股月/年成交彙總、鉅額交易明細、融券借券餘額/成交 | 16 個 |
 | [MIS 即時報價](https://mis.twse.com.tw) | 盤中即時多股報價（上市+上櫃） | 1 個 |
 | [TPEx OpenAPI](https://www.tpex.org.tw/openapi) | 櫃買中心 — 上櫃日收盤、三大法人（個股/彙總）、本益比、融資融券、注意/處置股、除權息、零股、指數 | 10 個 |
 | [TAIFEX OpenAPI](https://openapi.taifex.com.tw) | 期交所 — 三大法人系列、大額交易人部位、每日行情、選擇權分析、保證金、年月統計 | 16 個 |

--- a/README_en-us.md
+++ b/README_en-us.md
@@ -116,7 +116,7 @@ uv sync && uv run fastmcp dev server.py
 | Source | Description | Tools |
 |--------|-------------|-------|
 | [TWSE OpenAPI](https://openapi.twse.com.tw) | Taiwan Stock Exchange official API — corporate governance, ESG, financials, trading, indices, etc. | 143 |
-| [TWSE Web API](https://www.twse.com.tw) | TWSE web API endpoints — daily OHLC, monthly avg price, valuation, margin balance, listed stocks institutional investors (amounts/shares), whole-market daily close, TAIEX index history, foreign holdings history | 11 |
+| [TWSE Web API](https://www.twse.com.tw) | TWSE web API endpoints — daily OHLC, monthly avg price, valuation, margin balance, listed stocks institutional investors (amounts/shares), whole-market daily close, TAIEX index history, foreign holdings history, per-stock monthly/yearly summaries, block trade detail, short-sale/lending balance & trades | 16 |
 | [MIS Real-time Quotes](https://mis.twse.com.tw) | Intraday real-time multi-stock quotes (listed + OTC) | 1 |
 | [TPEx OpenAPI](https://www.tpex.org.tw/openapi) | TPEx OTC market — daily close, institutional investors (per-stock/summary), P/E ratio, margin balance, warning/disposal stocks, ex-rights/dividends, odd-lot, index | 10 |
 | [TAIFEX OpenAPI](https://openapi.taifex.com.tw) | TAIFEX derivatives — institutional series, large traders OI, daily market report, options analytics, margin, statistics | 16 |

--- a/tests/e2e/test_history_tier2_api.py
+++ b/tests/e2e/test_history_tier2_api.py
@@ -1,0 +1,101 @@
+"""
+測試 www.twse.com.tw/rwd 五個新增歷史查詢 API（NEW_TOOLS_PLAN.md Tier 2 TWSE 半）。
+只驗證 tools 中有寫死用到的欄位索引/位置，足以偵測來源 API 結構異動。
+"""
+
+import pytest
+from tests.helpers import fetch_or_skip
+
+FIXED_DATE = "20250103"  # 固定歷史交易日，確保資料穩定
+FIXED_STOCK = "2330"     # 台積電
+
+
+class TestStockMonthlyHistoryAPI:
+    """個股月成交資訊 - FMSRFK
+    Tool get_stock_monthly_history 使用 row[0]~row[8]：
+    年度、月份、最高價、最低價、加權平均價、成交筆數、成交金額、成交股數、週轉率。
+    """
+
+    def test_row_has_9_columns(self):
+        result = fetch_or_skip(
+            "https://www.twse.com.tw/rwd/zh/afterTrading/FMSRFK",
+            params={"response": "json", "date": FIXED_DATE, "stockNo": FIXED_STOCK},
+        )
+        assert result.get("stat") == "OK"
+        data = result.get("data", [])
+        assert len(data) > 0
+        assert len(data[0]) == 9, f"欄位數不為 9，row 結構可能已變更: {data[0]}"
+
+
+class TestStockYearlyHistoryAPI:
+    """個股歷年成交資訊 - FMNPTK
+    Tool get_stock_yearly_history 使用 tables[0] 的 row[0]~row[8]：
+    年度、成交股數、成交金額、成交筆數、最高價、日期、最低價、日期、收盤平均價。
+    """
+
+    def test_yearly_table_exists_with_9_columns(self):
+        result = fetch_or_skip(
+            "https://www.twse.com.tw/rwd/zh/afterTrading/FMNPTK",
+            params={"response": "json", "date": FIXED_DATE, "stockNo": FIXED_STOCK},
+        )
+        assert result.get("stat") == "OK"
+        tables = result.get("tables", [])
+        assert len(tables) > 0, "tables 結構可能已變更"
+        data = tables[0].get("data", [])
+        assert len(data) > 0
+        assert len(data[0]) == 9, f"欄位數不為 9，tables[0] row 結構可能已變更: {data[0]}"
+
+
+class TestBlockTradesDetailAPI:
+    """鉅額交易日成交資訊 - BFIAUU
+    Tool get_block_trades_detail 使用 row[0]~row[5]：
+    證券代號、證券名稱、交易別、成交價、成交股數、成交金額。
+    此端點無伺服器端股票代號篩選，tool 於本地端以 row[0] 過濾。
+    """
+
+    def test_row_has_6_columns(self):
+        result = fetch_or_skip(
+            "https://www.twse.com.tw/rwd/zh/block/BFIAUU",
+            params={"response": "json", "date": FIXED_DATE},
+        )
+        assert result.get("stat") == "OK"
+        data = result.get("data", [])
+        assert len(data) > 0
+        assert len(data[0]) == 6, f"欄位數不為 6，row 結構可能已變更: {data[0]}"
+
+
+class TestShortSaleLendingBalanceHistoryAPI:
+    """信用額度總量管制餘額表 - TWT93U
+    Tool get_short_sale_lending_balance_history 使用 row[0]~row[13]：
+    代號、名稱、融券(前日餘額/賣出/買進/現券/今日餘額/次一營業日限額)、
+    借券(前日餘額/當日賣出/當日還券/當日調整/當日餘額/次一營業日可限額)。
+    """
+
+    def test_row_has_at_least_14_columns(self):
+        result = fetch_or_skip(
+            "https://www.twse.com.tw/rwd/zh/marginTrading/TWT93U",
+            params={"response": "json", "date": FIXED_DATE, "selectType": "ALL"},
+        )
+        assert result.get("stat") == "OK"
+        data = result.get("data", [])
+        assert len(data) > 0
+        assert len(data[0]) >= 14, f"欄位數不足 14，row 結構可能已變更: {data[0]}"
+
+
+class TestShortSaleLendingTradesHistoryAPI:
+    """當日融券賣出與借券賣出成交量值 - TWTASU
+    Tool get_short_sale_lending_trades_history 使用 row[0]~row[4]：
+    證券名稱(含代號，以空白分隔)、融券賣出數量、融券賣出金額、借券賣出數量、借券賣出金額。
+    """
+
+    def test_row_has_5_columns_and_code_embedded_in_name(self):
+        result = fetch_or_skip(
+            "https://www.twse.com.tw/rwd/zh/afterTrading/TWTASU",
+            params={"response": "json", "date": FIXED_DATE},
+        )
+        assert result.get("stat") == "OK"
+        data = result.get("data", [])
+        assert len(data) > 0
+        assert len(data[0]) == 5, f"欄位數不為 5，row 結構可能已變更: {data[0]}"
+        tsmc = next((r for r in data if r[0].split(None, 1)[0] == FIXED_STOCK), None)
+        assert tsmc is not None, f"{FIXED_STOCK} 不在資料中，row[0] 的代號+名稱格式可能已變更"

--- a/tools/history/block_trades_detail.py
+++ b/tools/history/block_trades_detail.py
@@ -1,0 +1,74 @@
+"""TWSE block trade (鉅額交易) daily detail, per-transaction."""
+
+from typing import Optional
+from fastmcp import FastMCP
+from utils import TWSEAPIClient, handle_api_errors, DEFAULT_DISPLAY_LIMIT
+
+BFIAUU_URL = "https://www.twse.com.tw/rwd/zh/block/BFIAUU"
+
+
+def register_tools(mcp: FastMCP, client: Optional[TWSEAPIClient] = None) -> None:
+    """Register TWSE block trade detail tools."""
+    _client = client or TWSEAPIClient.get_instance()
+
+    @mcp.tool
+    @handle_api_errors()
+    def get_block_trades_detail(date: str, stock_no: str = "", name: str = "",
+                                 limit: int = DEFAULT_DISPLAY_LIMIT, offset: int = 0) -> str:
+        """查詢集中市場鉅額交易逐筆明細（含配對交易、盤後鉅額等交易別）。
+        與 get_block_trades_daily（openapi 版，僅有量值統計總數）不同，此工具回傳每一筆
+        鉅額交易的個股代號、交易別、成交價與成交量金額。
+        注意：來源端點不支援伺服器端股票代號篩選，stock_no/name 為本地端過濾。
+
+        Args:
+            date: 查詢日期，格式 YYYYMMDD，例如 "20260610"（需為交易日）
+            stock_no: 股票代號（選填），指定則只回傳該股票的鉅額交易
+            name: 股票名稱關鍵字（選填）
+            limit: 回傳筆數上限（預設 50）
+            offset: 跳過前 N 筆（預設 0，搭配 limit 分頁）
+
+        Returns:
+            每筆鉅額交易的股票代號、名稱、交易別、成交價、成交股數、成交金額
+        """
+        resp = _client.fetch_json(
+            BFIAUU_URL,
+            params={"response": "json", "date": date},
+        )
+
+        if not resp or resp.get("stat") != "OK":
+            return f"查無 {date} 的鉅額交易資料，請確認該日期為交易日（非假日或週末）"
+
+        data = resp.get("data", [])
+        if not data:
+            return f"查無 {date} 的鉅額交易資料"
+
+        if stock_no:
+            data = [row for row in data if row[0].strip() == stock_no]
+            if not data:
+                return f"查無股票代號 {stock_no} 在 {date} 的鉅額交易資料"
+        if name:
+            data = [row for row in data if name in row[1]]
+            if not data:
+                return f"查無名稱包含「{name}」的股票在 {date} 的鉅額交易資料"
+
+        total = len(data)
+        page_data = data[offset:offset + limit]
+        end = min(offset + limit, total)
+
+        title = resp.get("title", f"{date} 鉅額交易日成交資訊")
+        header = f"【{title}】（共 {total} 筆"
+        if total > limit or offset > 0:
+            header += f"，顯示第 {offset + 1}–{end} 筆"
+        header += "）\n"
+
+        lines = [header]
+        for row in page_data:
+            # row: 證券代號,證券名稱,交易別,成交價,成交股數,成交金額
+            code, sname, kind, price, volume, value = row
+            lines.append(f"{code} {sname} | {kind} | 價:{price} 量:{volume} 金額:{value}")
+
+        remaining = total - offset - limit
+        if remaining > 0:
+            lines.append(f"\n...還有 {remaining} 筆，使用 offset={offset + limit} 查看更多")
+
+        return "\n".join(lines)

--- a/tools/history/short_sale_lending.py
+++ b/tools/history/short_sale_lending.py
@@ -1,0 +1,155 @@
+"""TWSE short-sale (融券) and securities-lending (借券) balance/trading history.
+
+Complements tools/history/margin_balance.py's MI_MARGN (融資融券餘額), which does not
+cover the securities-lending (借券) side of short selling.
+"""
+
+from typing import Optional
+from fastmcp import FastMCP
+from utils import TWSEAPIClient, handle_api_errors, DEFAULT_DISPLAY_LIMIT
+
+TWT93U_URL = "https://www.twse.com.tw/rwd/zh/marginTrading/TWT93U"
+TWTASU_URL = "https://www.twse.com.tw/rwd/zh/afterTrading/TWTASU"
+
+
+def register_tools(mcp: FastMCP, client: Optional[TWSEAPIClient] = None) -> None:
+    """Register TWSE short-sale/securities-lending history tools."""
+    _client = client or TWSEAPIClient.get_instance()
+
+    @mcp.tool
+    @handle_api_errors()
+    def get_short_sale_lending_balance_history(date: str, stock_no: str = "", name: str = "",
+                                                limit: int = DEFAULT_DISPLAY_LIMIT, offset: int = 0) -> str:
+        """查詢信用額度總量管制餘額表：融券賣出餘額與借券賣出餘額。
+        與 get_margin_balance（融資融券）不同，此工具涵蓋借券賣出（證券出借）的餘額面。
+
+        Args:
+            date: 查詢日期，格式 YYYYMMDD，例如 "20260610"（需為交易日）
+            stock_no: 股票代號（選填），指定則只回傳該股票
+            name: 股票名稱關鍵字（選填）
+            limit: 回傳筆數上限（預設 50）
+            offset: 跳過前 N 筆（預設 0，搭配 limit 分頁）
+
+        Returns:
+            每支股票的融券（前日餘額/賣出/買進/現券/今日餘額/次一營業日限額）及
+            借券（前日餘額/當日賣出/當日還券/當日調整/當日餘額/次一營業日可限額）
+        """
+        resp = _client.fetch_json(
+            TWT93U_URL,
+            params={"response": "json", "date": date, "selectType": "ALL"},
+        )
+
+        if not resp or resp.get("stat") != "OK":
+            return f"查無 {date} 的信用額度總量管制餘額資料，請確認該日期為交易日（非假日或週末）"
+
+        data = resp.get("data", [])
+        if not data:
+            return f"查無 {date} 的信用額度總量管制餘額資料"
+
+        if stock_no:
+            data = [row for row in data if row[0].strip() == stock_no]
+            if not data:
+                return f"查無股票代號 {stock_no} 在 {date} 的信用額度總量管制餘額資料"
+        if name:
+            data = [row for row in data if name in row[1]]
+            if not data:
+                return f"查無名稱包含「{name}」的股票在 {date} 的信用額度總量管制餘額資料"
+
+        total = len(data)
+        page_data = data[offset:offset + limit]
+        end = min(offset + limit, total)
+
+        title = resp.get("title", f"{date} 信用額度總量管制餘額表")
+        header = f"【{title}】（共 {total} 筆"
+        if total > limit or offset > 0:
+            header += f"，顯示第 {offset + 1}–{end} 筆"
+        header += "）\n"
+
+        lines = [header]
+        for row in page_data:
+            # row: 代號,名稱,前日餘額,賣出,買進,現券,今日餘額,次一營業日限額,
+            #      前日餘額,當日賣出,當日還券,當日調整,當日餘額,次一營業日可限額,備註
+            code, sname = row[0], row[1]
+            ss_prev, ss_sell, ss_buy, ss_cash, ss_today, ss_limit = row[2:8]
+            sl_prev, sl_sell, sl_return, sl_adjust, sl_today, sl_limit = row[8:14]
+            lines.append(
+                f"{code} {sname}\n"
+                f"  融券: 前日{ss_prev} 賣出{ss_sell} 買進{ss_buy} 現券{ss_cash} 今日{ss_today} 次日限額{ss_limit}\n"
+                f"  借券: 前日{sl_prev} 當日賣出{sl_sell} 當日還券{sl_return} 調整{sl_adjust} 當日{sl_today} 次日可限額{sl_limit}"
+            )
+
+        remaining = total - offset - limit
+        if remaining > 0:
+            lines.append(f"\n...還有 {remaining} 筆，使用 offset={offset + limit} 查看更多")
+
+        return "\n".join(lines)
+
+    @mcp.tool
+    @handle_api_errors()
+    def get_short_sale_lending_trades_history(date: str, stock_no: str = "", name: str = "",
+                                               limit: int = DEFAULT_DISPLAY_LIMIT, offset: int = 0) -> str:
+        """查詢當日融券賣出與借券賣出成交量值。
+        與 get_short_sale_lending_balance_history（餘額）互補，此工具是「當日實際成交」的量與金額。
+
+        Args:
+            date: 查詢日期，格式 YYYYMMDD，例如 "20260610"（需為交易日）
+            stock_no: 股票代號（選填），指定則只回傳該股票
+            name: 股票名稱關鍵字（選填）
+            limit: 回傳筆數上限（預設 50）
+            offset: 跳過前 N 筆（預設 0，搭配 limit 分頁）
+
+        Returns:
+            每支股票的融券賣出成交數量/金額、借券賣出成交數量/金額
+        """
+        resp = _client.fetch_json(
+            TWTASU_URL,
+            params={"response": "json", "date": date},
+        )
+
+        if not resp or resp.get("stat") != "OK":
+            return f"查無 {date} 的融券借券賣出成交量值資料，請確認該日期為交易日（非假日或週末）"
+
+        data = resp.get("data", [])
+        if not data:
+            return f"查無 {date} 的融券借券賣出成交量值資料"
+
+        # row[0] combines code and name in one padded string, e.g. "2330   台積電"
+        parsed = []
+        for row in data:
+            code_name = row[0].split(None, 1)
+            code = code_name[0] if code_name else ""
+            sname = code_name[1].strip() if len(code_name) > 1 else ""
+            parsed.append((code, sname, row))
+
+        if stock_no:
+            parsed = [p for p in parsed if p[0] == stock_no]
+            if not parsed:
+                return f"查無股票代號 {stock_no} 在 {date} 的融券借券賣出成交量值資料"
+        if name:
+            parsed = [p for p in parsed if name in p[1]]
+            if not parsed:
+                return f"查無名稱包含「{name}」的股票在 {date} 的融券借券賣出成交量值資料"
+
+        total = len(parsed)
+        page_data = parsed[offset:offset + limit]
+        end = min(offset + limit, total)
+
+        title = resp.get("title", f"{date} 當日融券賣出與借券賣出成交量值")
+        header = f"【{title}】（共 {total} 筆"
+        if total > limit or offset > 0:
+            header += f"，顯示第 {offset + 1}–{end} 筆"
+        header += "）\n"
+
+        lines = [header]
+        for code, sname, row in page_data:
+            # row: 證券名稱(含代號),融券賣出數量,融券賣出金額,借券賣出數量,借券賣出金額
+            ss_vol, ss_val, sl_vol, sl_val = row[1], row[2], row[3], row[4]
+            lines.append(
+                f"{code} {sname} | 融券賣出: 量{ss_vol} 金額{ss_val} | 借券賣出: 量{sl_vol} 金額{sl_val}"
+            )
+
+        remaining = total - offset - limit
+        if remaining > 0:
+            lines.append(f"\n...還有 {remaining} 筆，使用 offset={offset + limit} 查看更多")
+
+        return "\n".join(lines)

--- a/tools/history/stock_monthly_yearly_history.py
+++ b/tools/history/stock_monthly_yearly_history.py
@@ -1,0 +1,89 @@
+"""TWSE per-stock monthly/yearly aggregated trading history."""
+
+from typing import Optional
+from fastmcp import FastMCP
+from utils import TWSEAPIClient, handle_api_errors
+
+FMSRFK_URL = "https://www.twse.com.tw/rwd/zh/afterTrading/FMSRFK"
+FMNPTK_URL = "https://www.twse.com.tw/rwd/zh/afterTrading/FMNPTK"
+
+
+def register_tools(mcp: FastMCP, client: Optional[TWSEAPIClient] = None) -> None:
+    """Register TWSE per-stock monthly/yearly history tools."""
+    _client = client or TWSEAPIClient.get_instance()
+
+    @mcp.tool
+    @handle_api_errors(use_code_param=True)
+    def get_stock_monthly_history(stock_no: str, date: str) -> str:
+        """查詢個股月成交資訊（最高價、最低價、加權平均價、週轉率）。
+        與 get_stock_monthly_avg_history（每日的月均價序列）不同，此工具是「每月一筆」的彙總。
+        只有 date 的年份會影響查詢結果：查當年會回傳至今每月資料，查過去年份則回傳該年全部12個月。
+
+        Args:
+            stock_no: 股票代號，例如 "2330"（台積電）
+            date: 任意日期 YYYYMMDD，僅年份有效，例如 "20250101" 查民國114年整年
+
+        Returns:
+            該年度每月的最高價、最低價、加權平均價、成交筆數、成交金額、成交股數、週轉率
+        """
+        resp = _client.fetch_json(
+            FMSRFK_URL,
+            params={"response": "json", "date": date, "stockNo": stock_no},
+        )
+
+        if not resp or resp.get("stat") != "OK":
+            return f"查無股票代號 {stock_no} 的月成交資訊，請確認代號是否正確"
+
+        data = resp.get("data", [])
+        if not data:
+            return f"查無股票代號 {stock_no} 的月成交資訊"
+
+        title = resp.get("title", f"{stock_no} 月成交資訊")
+        lines = [f"【{title}】\n"]
+        for row in data:
+            # row: 年度,月份,最高價,最低價,加權(A/B)平均價,成交筆數,成交金額(A),成交股數(B),週轉率(%)
+            year, month, high, low, avg, tx, value, volume, turnover = row
+            lines.append(
+                f"{year}/{int(month):02d} | 最高:{high} 最低:{low} 加權均價:{avg} | "
+                f"量:{volume} 金額:{value} 筆數:{tx} | 週轉率:{turnover}%"
+            )
+
+        return "\n".join(lines)
+
+    @mcp.tool
+    @handle_api_errors(use_code_param=True)
+    def get_stock_yearly_history(stock_no: str) -> str:
+        """查詢個股歷年成交資訊（最高價、最低價、收盤平均價），資料可回溯數十年。
+        與 get_stock_monthly_history（單一年度逐月）互補，此工具是「每年一筆」的長期彙總，
+        適合看個股長期價格區間演變。
+
+        Args:
+            stock_no: 股票代號，例如 "2330"（台積電）
+
+        Returns:
+            每年度的最高價（及日期）、最低價（及日期）、收盤平均價、成交股數、成交金額、成交筆數
+        """
+        resp = _client.fetch_json(
+            FMNPTK_URL,
+            params={"response": "json", "date": "20260101", "stockNo": stock_no},
+        )
+
+        if not resp or resp.get("stat") != "OK":
+            return f"查無股票代號 {stock_no} 的歷年成交資訊，請確認代號是否正確"
+
+        tables = resp.get("tables", [])
+        yearly_table = tables[0] if tables else None
+        data = yearly_table.get("data") if yearly_table else None
+        if not data:
+            return f"查無股票代號 {stock_no} 的歷年成交資訊"
+
+        lines = [f"【{stock_no} 歷年成交資訊】（共 {len(data)} 年）\n"]
+        for row in data:
+            # row: 年度,成交股數,成交金額,成交筆數,最高價,日期(最高),最低價,日期(最低),收盤平均價
+            year, volume, value, tx, high, high_date, low, low_date, avg_close = row
+            lines.append(
+                f"{year}年 | 最高:{high}（{high_date}） 最低:{low}（{low_date}） 收盤均價:{avg_close} | "
+                f"量:{volume} 金額:{value} 筆數:{tx}"
+            )
+
+        return "\n".join(lines)


### PR DESCRIPTION
## Summary

TWSE half of NEW_TOOLS_PLAN.md Tier 2 (#10, #14, #15 — #15 split into two separate tools since "balance" and "same-day trades" answer different questions, matching the one-tool-per-endpoint convention used throughout this project).

## New tools
- **`get_stock_monthly_history`** / **`get_stock_yearly_history`** — per-stock monthly (`FMSRFK`) and yearly (`FMNPTK`) turnover summaries. `FMNPTK` returns a `tables` shape (not `data`) with a duplicate `"日期"` header name (once for the high-price date, once for the low-price date), so it's accessed positionally rather than by field name. Yearly history goes back to ROC year 83 (1994) for TSMC — verified live, not assumed.
- **`get_block_trades_detail`** — per-transaction block trade detail (`BFIAUU`), complementing the existing `get_block_trades_daily` (openapi, aggregate stats only). Verified the `stockNo` query param is silently ignored server-side (identical row count with/without it), so filtering happens client-side — same pattern as `largeTraderFutDown` from #54.
- **`get_short_sale_lending_balance_history`** / **`get_short_sale_lending_trades_history`** — 融券/借券 balance (`TWT93U`) and same-day trade volume (`TWTASU`), filling the securities-lending gap the existing `get_margin_balance` (MI_MARGN) doesn't cover. Found the correct endpoint paths by actually loading the live TWSE page, triggering its query, and reading the resulting network request — my first guesses at both paths were wrong (`marginTrading` not `margin`; `TWTASU` lives under `afterTrading` not `margin`). `TWTASU` has no separate stock-code field — code and name are concatenated in one padded string (`"2330   台積電          "`), parsed with `str.split(None, 1)`.

## Test plan
- [x] `python -m py_compile` on all new/changed files
- [x] Booted the real `server.py` FastMCP instance and called all 5 tools live through `mcp._tool_manager.call_tool(...)` — verified real output for TSMC (6 months of 2026 data, 32 years of yearly history, 11 block trades on 2026/06/10, margin/lending balance and same-day trade figures)
- [x] Added `tests/e2e/test_history_tier2_api.py` asserting the row shape each tool accesses by index — 5 passed
- [x] Ran the full history test suite (`test_history_api.py` + `test_twse_institutional_api.py` + `test_history_tier1_api.py` + `test_history_tier2_api.py`) — 17 passed, no regressions
- [x] Total tool count: 172 → 177 as expected