### PR TITLE
feat: add TAIFEX Tier 2 historical-data tools (3 new tools)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ TWStockMCPServer is a Model Context Protocol (MCP) server for Taiwan stock marke
 - **MIS 即時報價** (`mis.twse.com.tw`) — 1 tool: 盤中多股即時報價
 - **TPEx OpenAPI** (`tpex.org.tw/openapi`) — 3 tools: 上櫃日收盤、三大法人、本益比
 - **TAIFEX OpenAPI** (`openapi.taifex.com.tw`) — 16 tools: 三大法人系列、大額交易人部位、每日行情、選擇權分析（Delta/OI增減）、保證金、年月統計
-- **TAIFEX 網站下載** (`www.taifex.com.tw`) — 6 tools: 期貨每日OHLC歷史、三大法人期貨部位歷史、Put/Call Ratio歷史、三大法人選擇權買賣權分計歷史、大額交易人未沖銷部位歷史（無伺服器端契約篩選，本地端過濾）、選擇權每日OHLC歷史（HTML表單下載頁面，非 openapi.taifex.com.tw；後者無任何歷史查詢功能，僅回傳最新一個交易日）
+- **TAIFEX 網站下載** (`www.taifex.com.tw`) — 9 tools: 期貨每日OHLC歷史、三大法人期貨部位歷史、Put/Call Ratio歷史、三大法人選擇權買賣權分計歷史、大額交易人未沖銷部位歷史（無伺服器端契約篩選，本地端過濾）、選擇權每日OHLC歷史、三大法人期貨+選擇權總表歷史、三大法人期貨/選擇權分計歷史、三大法人各選擇權契約歷史（HTML表單下載頁面，非 openapi.taifex.com.tw；後者無任何歷史查詢功能，僅回傳最新一個交易日）
 
 ## Development Commands
 
@@ -60,10 +60,13 @@ tools/
                               #   options_analytics, margin, trading_statistics, futures_daily_history,
                               #   institutional_futures_history, put_call_ratio_history,
                               #   options_institutional_history, large_traders_futures_history,
-                              #   options_daily_history (latter six scrape www.taifex.com.tw's
-                              #   HTML-form download endpoints for multi-day history; openapi.taifex.com.tw
-                              #   has no historical query support — every openapi endpoint returns only
-                              #   the latest trading day, confirmed by testing all 135 of its endpoints)
+                              #   options_daily_history, institutional_total_history,
+                              #   institutional_fut_opt_split_history,
+                              #   options_institutional_by_contract_history (latter nine scrape
+                              #   www.taifex.com.tw's HTML-form download endpoints for multi-day
+                              #   history; openapi.taifex.com.tw has no historical query support —
+                              #   every openapi endpoint returns only the latest trading day,
+                              #   confirmed by testing all 135 of its endpoints)
 prompts/                      # 9 prompt templates registered in server.py
 ```
 

--- a/NEW_TOOLS_PLAN.md
+++ b/NEW_TOOLS_PLAN.md
@@ -53,6 +53,7 @@
 
 ## 進度
 
-- [ ] PR-A：TWSE Tier 1（#1–#5）
-- [ ] PR-B：TAIFEX Tier 1（#6–#9）
-- [ ] PR-C：Tier 2（#10–#15）
+- [x] PR-A：TWSE Tier 1（#1–#5）— #53
+- [x] PR-B：TAIFEX Tier 1（#6–#9）— #54
+- [x] PR-C1：TWSE Tier 2（#10, #14, #15）— #56
+- [x] PR-C2：TAIFEX Tier 2（#11–#13）— 本 PR

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ uv sync && uv run fastmcp dev server.py
 | [MIS 即時報價](https://mis.twse.com.tw) | 盤中即時多股報價（上市+上櫃） | 1 個 |
 | [TPEx OpenAPI](https://www.tpex.org.tw/openapi) | 櫃買中心 — 上櫃日收盤、三大法人（個股/彙總）、本益比、融資融券、注意/處置股、除權息、零股、指數 | 10 個 |
 | [TAIFEX OpenAPI](https://openapi.taifex.com.tw) | 期交所 — 三大法人系列、大額交易人部位、每日行情、選擇權分析、保證金、年月統計 | 16 個 |
-| [TAIFEX 網站下載](https://www.taifex.com.tw) | 期交所網站歷史資料下載頁面 — 期貨每日OHLC歷史、三大法人期貨部位歷史、Put/Call Ratio歷史、三大法人選擇權買賣權分計歷史、大額交易人未沖銷部位歷史、選擇權每日OHLC歷史（openapi.taifex.com.tw 僅提供最新一日，無歷史查詢功能） | 6 個 |
+| [TAIFEX 網站下載](https://www.taifex.com.tw) | 期交所網站歷史資料下載頁面 — 期貨每日OHLC歷史、三大法人期貨部位歷史、Put/Call Ratio歷史、三大法人選擇權買賣權分計歷史、大額交易人未沖銷部位歷史、選擇權每日OHLC歷史、三大法人期貨+選擇權總表歷史、三大法人期貨/選擇權分計歷史、三大法人各選擇權契約歷史（openapi.taifex.com.tw 僅提供最新一日，無歷史查詢功能） | 9 個 |
 
 ## 🤝 參與貢獻
 歡迎PR！

--- a/README_en-us.md
+++ b/README_en-us.md
@@ -120,7 +120,7 @@ uv sync && uv run fastmcp dev server.py
 | [MIS Real-time Quotes](https://mis.twse.com.tw) | Intraday real-time multi-stock quotes (listed + OTC) | 1 |
 | [TPEx OpenAPI](https://www.tpex.org.tw/openapi) | TPEx OTC market — daily close, institutional investors (per-stock/summary), P/E ratio, margin balance, warning/disposal stocks, ex-rights/dividends, odd-lot, index | 10 |
 | [TAIFEX OpenAPI](https://openapi.taifex.com.tw) | TAIFEX derivatives — institutional series, large traders OI, daily market report, options analytics, margin, statistics | 16 |
-| [TAIFEX website downloads](https://www.taifex.com.tw) | TAIFEX's own historical data-download pages — futures daily OHLC history, 三大法人 futures position history, Put/Call Ratio history, 三大法人 options calls/puts history, large-trader futures OI history, options daily OHLC history (openapi.taifex.com.tw only returns the latest trading day, no historical query support) | 6 |
+| [TAIFEX website downloads](https://www.taifex.com.tw) | TAIFEX's own historical data-download pages — futures daily OHLC history, 三大法人 futures position history, Put/Call Ratio history, 三大法人 options calls/puts history, large-trader futures OI history, options daily OHLC history, 三大法人 futures+options total history, futures/options split history, options-by-contract history (openapi.taifex.com.tw only returns the latest trading day, no historical query support) | 9 |
 
 ## 🤝 Contributing
 PRs welcome!

--- a/tests/e2e/test_taifex_history_api.py
+++ b/tests/e2e/test_taifex_history_api.py
@@ -190,3 +190,69 @@ class TestOptionsDailyHistoryAPI:
         )
         contracts = set(r[1].strip() for r in rows[1:] if r and len(r) > 1)
         assert contracts == {"TXO"}, f"commodity_id 篩選行為可能已變更: {contracts}"
+
+
+class TestInstitutionalTotalHistoryAPI:
+    """Tool get_institutional_total_history 依 index 存取的欄位順序：
+    0=日期 1=身份別 2=多方交易口數 3=多方交易契約金額(百萬元) 4=空方交易口數
+    5=空方交易契約金額(百萬元) 6=多空交易口數淨額 7=多空交易契約金額淨額(百萬元)
+    8=多方未平倉口數 10=空方未平倉口數 12=多空未平倉口數淨額
+    """
+
+    def test_hardcoded_column_order(self):
+        rows = _post_csv(
+            "https://www.taifex.com.tw/cht/3/totalTableDateDown",
+            {"queryStartDate": "2026/06/01", "queryEndDate": "2026/06/03"},
+        )
+        assert len(rows) > 1, "查無資料，無法驗證欄位順序"
+        header = rows[0]
+        expected = [
+            "日期", "身份別",
+            "多方交易口數", "多方交易契約金額(百萬元)", "空方交易口數", "空方交易契約金額(百萬元)",
+            "多空交易口數淨額", "多空交易契約金額淨額(百萬元)",
+            "多方未平倉口數", "多方未平倉契約金額(百萬元)", "空方未平倉口數", "空方未平倉契約金額(百萬元)",
+            "多空未平倉口數淨額", "多空未平倉契約金額淨額(百萬元)",
+        ]
+        assert header == expected, f"欄位順序異動: {header}"
+
+
+class TestOptionsInstitutionalByContractHistoryAPI:
+    """Tool get_options_institutional_by_contract_history 依 index 存取的欄位順序：
+    0=日期 1=商品名稱 2=身份別 3=多方交易口數 5=空方交易口數 7=多空交易口數淨額
+    9=多方未平倉口數 11=空方未平倉口數 13=多空未平倉口數淨額
+    """
+
+    def test_hardcoded_column_order(self):
+        rows = _post_csv(
+            "https://www.taifex.com.tw/cht/3/optContractsDateDown",
+            {"queryStartDate": "2026/06/01", "queryEndDate": "2026/06/03", "commodityId": "TXO"},
+        )
+        assert len(rows) > 1, "查無資料，無法驗證欄位順序"
+        header = rows[0]
+        expected = [
+            "日期", "商品名稱", "身份別",
+            "多方交易口數", "多方交易契約金額(千元)", "空方交易口數", "空方交易契約金額(千元)",
+            "多空交易口數淨額", "多空交易契約金額淨額(千元)",
+            "多方未平倉口數", "多方未平倉契約金額(千元)", "空方未平倉口數", "空方未平倉契約金額(千元)",
+            "多空未平倉口數淨額", "多空未平倉契約金額淨額(千元)",
+        ]
+        assert header == expected, f"欄位順序異動: {header}"
+
+
+class TestInstitutionalFutOptSplitHistoryAPI:
+    """Tool get_institutional_fut_opt_split_history 依 index 存取的欄位（期貨=偶數index、選擇權=奇數index）：
+    0=日期 1=身份別 2/3=多方交易口數(期貨/選擇權) 6/7=空方交易口數 10/11=多空交易口數淨額
+    14/15=多方未平倉口數 18/19=空方未平倉口數 22/23=多空未平倉口數淨額
+    """
+
+    def test_hardcoded_column_order(self):
+        rows = _post_csv(
+            "https://www.taifex.com.tw/cht/3/futAndOptDateDown",
+            {"queryStartDate": "2026/06/01", "queryEndDate": "2026/06/03"},
+        )
+        assert len(rows) > 1, "查無資料，無法驗證欄位順序"
+        header = rows[0]
+        assert len(header) == 26, f"欄位數不為 26，header 結構可能已變更: {header}"
+        assert header[0] == "日期" and header[1] == "身份別", f"前兩欄異動: {header[:2]}"
+        assert "期貨" in header[2] and "選擇權" in header[3], f"欄位2/3應為期貨/選擇權多方交易口數: {header[2:4]}"
+        assert "期貨" in header[22] and "選擇權" in header[23], f"欄位22/23應為期貨/選擇權多空未平倉口數淨額: {header[22:24]}"

--- a/tools/taifex/institutional_fut_opt_split_history.py
+++ b/tools/taifex/institutional_fut_opt_split_history.py
@@ -1,0 +1,89 @@
+"""TAIFEX 三大法人期貨/選擇權二類分計 history (multi-day download, futures vs options side by side)."""
+
+from typing import Optional
+from fastmcp import FastMCP
+from utils import TWSEAPIClient, handle_api_errors
+from .futures_position import TAIFEX_HEADERS
+from .futures_daily_history import parse_yyyymmdd, decode_and_parse_csv
+
+# Distinct from get_institutional_total_history (futures+options combined into one
+# number) and get_institutional_traders_by_futures_history (futures only): this endpoint
+# reports futures and options side by side per identity, so the two can be compared
+# directly. openapi.taifex.com.tw has no equivalent at all — this data isn't exposed
+# there under any endpoint. No server-enforced span cap observed (tested a clean 3-month
+# pull), capped client-side at 92 days. Retention verified to run out between 2023/06 and
+# 2023/09.
+FUT_AND_OPT_DATE_DOWN_URL = "https://www.taifex.com.tw/cht/3/futAndOptDateDown"
+
+MAX_SPAN_DAYS = 92
+
+
+def register_tools(mcp: FastMCP, client: Optional[TWSEAPIClient] = None) -> None:
+    """Register TAIFEX institutional futures-vs-options split history tools."""
+    _client = client or TWSEAPIClient.get_instance()
+
+    @mcp.tool
+    @handle_api_errors()
+    def get_institutional_fut_opt_split_history(start_date: str, end_date: str) -> str:
+        """查詢三大法人期貨與選擇權分計交易歷史（期貨、選擇權並列顯示，可回溯查詢）。
+        與 get_institutional_total_history（期貨+選擇權合計成一個數字）不同，此工具將期貨與
+        選擇權的多空交易口數、契約金額、未平倉分開列出，方便比較兩者布局是否一致。
+        此資料在 openapi.taifex.com.tw 完全沒有對應端點。
+
+        Args:
+            start_date: 起始日期，格式 YYYYMMDD，例如 "20260401"
+            end_date: 結束日期，格式 YYYYMMDD。與 start_date 區間不可超過 92 天
+
+        Returns:
+            區間內每個交易日、每個身份別（自營商/投信/外資及陸資）的期貨與選擇權各自多空
+            交易口數、契約金額（千元）、未平倉口數
+        """
+        try:
+            start_dt = parse_yyyymmdd(start_date)
+            end_dt = parse_yyyymmdd(end_date)
+        except ValueError:
+            return f"日期格式錯誤，請使用 YYYYMMDD 格式（例如 20260401），收到：start_date={start_date}, end_date={end_date}"
+
+        if start_dt > end_dt:
+            return f"起始日期 {start_date} 不可晚於結束日期 {end_date}"
+        if (end_dt - start_dt).days > MAX_SPAN_DAYS:
+            return f"查詢區間不可超過 {MAX_SPAN_DAYS} 天（收到 {(end_dt - start_dt).days} 天），請縮小 start_date～end_date 範圍後重試"
+
+        body = _client.fetch_bytes(
+            FUT_AND_OPT_DATE_DOWN_URL,
+            method="POST",
+            headers=TAIFEX_HEADERS,
+            data={
+                "queryStartDate": start_dt.strftime("%Y/%m/%d"),
+                "queryEndDate": end_dt.strftime("%Y/%m/%d"),
+            },
+        )
+        parsed = decode_and_parse_csv(body)
+        if parsed is None:
+            return (
+                f"查無 {start_date}～{end_date} 的三大法人期貨/選擇權分計資料，"
+                f"日期區間可能超出資料保存範圍（約近 3 年內）或格式有誤"
+            )
+
+        _header, data_rows = parsed
+        lines = [
+            f"【三大法人期貨/選擇權分計歷史】區間:{start_date}~{end_date}（共 {len(data_rows)} 筆）\n"
+        ]
+        for r in data_rows:
+            date, identity = r[0], r[1]
+            # 偶數 index = 期貨欄位, 奇數 index = 選擇權欄位
+            fut_long_vol, opt_long_vol = r[2], r[3]
+            fut_short_vol, opt_short_vol = r[6], r[7]
+            fut_net_vol, opt_net_vol = r[10], r[11]
+            fut_oi_long, opt_oi_long = r[14], r[15]
+            fut_oi_short, opt_oi_short = r[18], r[19]
+            fut_oi_net, opt_oi_net = r[22], r[23]
+            lines.append(
+                f"{date} | {identity}\n"
+                f"  期貨: 交易 多{fut_long_vol}/空{fut_short_vol}/淨{fut_net_vol} | "
+                f"未平倉 多{fut_oi_long}/空{fut_oi_short}/淨{fut_oi_net}\n"
+                f"  選擇權: 交易 多{opt_long_vol}/空{opt_short_vol}/淨{opt_net_vol} | "
+                f"未平倉 多{opt_oi_long}/空{opt_oi_short}/淨{opt_oi_net}"
+            )
+
+        return "\n".join(lines)

--- a/tools/taifex/institutional_total_history.py
+++ b/tools/taifex/institutional_total_history.py
@@ -1,0 +1,80 @@
+"""TAIFEX 三大法人期貨+選擇權總表 history (multi-day download)."""
+
+from typing import Optional
+from fastmcp import FastMCP
+from utils import TWSEAPIClient, handle_api_errors
+from .futures_position import TAIFEX_HEADERS
+from .futures_daily_history import parse_yyyymmdd, decode_and_parse_csv
+
+# openapi.taifex.com.tw's get_institutional_general only returns the latest trading day.
+# This endpoint (www.taifex.com.tw download page) accepts an arbitrary date range. No
+# server-enforced span cap observed (tested a clean 3-month pull), capped client-side at
+# 92 days to bound tool output. Retention verified to run out between 2023/06 and 2023/09,
+# matching the other TAIFEX history tools built on this same download-page family.
+TOTAL_TABLE_DATE_DOWN_URL = "https://www.taifex.com.tw/cht/3/totalTableDateDown"
+
+MAX_SPAN_DAYS = 92
+
+
+def register_tools(mcp: FastMCP, client: Optional[TWSEAPIClient] = None) -> None:
+    """Register TAIFEX institutional futures+options total table history tools."""
+    _client = client or TWSEAPIClient.get_instance()
+
+    @mcp.tool
+    @handle_api_errors()
+    def get_institutional_total_history(start_date: str, end_date: str) -> str:
+        """查詢三大法人期貨與選擇權合計總表歷史（可回溯查詢，非僅最新一日）。
+        與 get_institutional_general（openapi 版，僅能查最新一個交易日）不同，此工具可查詢
+        任意過去起訖日期。與 get_institutional_traders_by_futures_history（僅期貨）不同，
+        此工具是期貨+選擇權合計數字。
+
+        Args:
+            start_date: 起始日期，格式 YYYYMMDD，例如 "20260401"
+            end_date: 結束日期，格式 YYYYMMDD。與 start_date 區間不可超過 92 天
+
+        Returns:
+            區間內每個交易日、每個身份別（自營商/投信/外資及陸資）的期貨+選擇權合計多空交易口數、
+            契約金額（百萬元）、未平倉資訊
+        """
+        try:
+            start_dt = parse_yyyymmdd(start_date)
+            end_dt = parse_yyyymmdd(end_date)
+        except ValueError:
+            return f"日期格式錯誤，請使用 YYYYMMDD 格式（例如 20260401），收到：start_date={start_date}, end_date={end_date}"
+
+        if start_dt > end_dt:
+            return f"起始日期 {start_date} 不可晚於結束日期 {end_date}"
+        if (end_dt - start_dt).days > MAX_SPAN_DAYS:
+            return f"查詢區間不可超過 {MAX_SPAN_DAYS} 天（收到 {(end_dt - start_dt).days} 天），請縮小 start_date～end_date 範圍後重試"
+
+        body = _client.fetch_bytes(
+            TOTAL_TABLE_DATE_DOWN_URL,
+            method="POST",
+            headers=TAIFEX_HEADERS,
+            data={
+                "queryStartDate": start_dt.strftime("%Y/%m/%d"),
+                "queryEndDate": end_dt.strftime("%Y/%m/%d"),
+            },
+        )
+        parsed = decode_and_parse_csv(body)
+        if parsed is None:
+            return (
+                f"查無 {start_date}～{end_date} 的三大法人期貨+選擇權總表資料，"
+                f"日期區間可能超出資料保存範圍（約近 3 年內）或格式有誤"
+            )
+
+        _header, data_rows = parsed
+        lines = [f"【三大法人期貨+選擇權總表歷史】區間:{start_date}~{end_date}（共 {len(data_rows)} 筆）\n"]
+        for r in data_rows:
+            date, identity = r[0], r[1]
+            long_vol, long_amt = r[2], r[3]
+            short_vol, short_amt = r[4], r[5]
+            net_vol, net_amt = r[6], r[7]
+            oi_long, oi_short, oi_net = r[8], r[10], r[12]
+            lines.append(
+                f"{date} | {identity}\n"
+                f"  交易: 多 {long_vol}({long_amt}百萬元) / 空 {short_vol}({short_amt}百萬元) / 淨 {net_vol}({net_amt}百萬元)\n"
+                f"  未平倉: 多 {oi_long} / 空 {oi_short} / 淨 {oi_net}"
+            )
+
+        return "\n".join(lines)

--- a/tools/taifex/options_institutional_by_contract_history.py
+++ b/tools/taifex/options_institutional_by_contract_history.py
@@ -1,0 +1,88 @@
+"""TAIFEX 三大法人各選擇權契約 history (multi-day download, aggregated across CALL+PUT)."""
+
+from typing import Optional
+from fastmcp import FastMCP
+from utils import TWSEAPIClient, handle_api_errors
+from .futures_position import TAIFEX_HEADERS
+from .futures_daily_history import parse_yyyymmdd, decode_and_parse_csv
+
+# Distinct from get_options_institutional_calls_puts_history: that tool splits CALL vs
+# PUT; this endpoint (optContractsDateDown) reports each contract's totals with CALL and
+# PUT combined. openapi.taifex.com.tw's get_institutional_traders_by_options only returns
+# the latest trading day; this download-page endpoint accepts an arbitrary date range. No
+# server-enforced span cap observed (tested a clean 3-month pull), capped client-side at
+# 92 days. Retention verified to run out between 2023/06 and 2023/09.
+OPT_CONTRACTS_DATE_DOWN_URL = "https://www.taifex.com.tw/cht/3/optContractsDateDown"
+
+MAX_SPAN_DAYS = 92
+
+
+def register_tools(mcp: FastMCP, client: Optional[TWSEAPIClient] = None) -> None:
+    """Register TAIFEX institutional options-by-contract history tools."""
+    _client = client or TWSEAPIClient.get_instance()
+
+    @mcp.tool
+    @handle_api_errors()
+    def get_options_institutional_by_contract_history(start_date: str, end_date: str, contract: str = "TXO") -> str:
+        """查詢三大法人各選擇權契約交易歷史（CALL+PUT合計，可回溯查詢，非僅最新一日）。
+        與 get_options_institutional_calls_puts_history（同樣可回溯，但拆分 CALL/PUT）不同，
+        此工具回傳的是該選擇權契約 CALL 與 PUT 合計後的總數。
+        與 get_institutional_traders_by_options（openapi 版，僅能查最新一個交易日）不同，
+        此工具可查詢任意過去起訖日期。
+
+        Args:
+            start_date: 起始日期，格式 YYYYMMDD，例如 "20260401"
+            end_date: 結束日期，格式 YYYYMMDD。與 start_date 區間不可超過 92 天
+            contract: 選擇權契約代碼，預設 TXO（臺指選擇權）。其他常用：TEO（電子選擇權）、
+                TFO（金融選擇權）
+
+        Returns:
+            區間內每個交易日、每個身份別（自營商/投信/外資）在該契約的CALL+PUT合計多空交易口數、
+            契約金額、未平倉資訊
+        """
+        try:
+            start_dt = parse_yyyymmdd(start_date)
+            end_dt = parse_yyyymmdd(end_date)
+        except ValueError:
+            return f"日期格式錯誤，請使用 YYYYMMDD 格式（例如 20260401），收到：start_date={start_date}, end_date={end_date}"
+
+        if start_dt > end_dt:
+            return f"起始日期 {start_date} 不可晚於結束日期 {end_date}"
+        if (end_dt - start_dt).days > MAX_SPAN_DAYS:
+            return f"查詢區間不可超過 {MAX_SPAN_DAYS} 天（收到 {(end_dt - start_dt).days} 天），請縮小 start_date～end_date 範圍後重試"
+
+        contract = contract.strip().upper()
+        body = _client.fetch_bytes(
+            OPT_CONTRACTS_DATE_DOWN_URL,
+            method="POST",
+            headers=TAIFEX_HEADERS,
+            data={
+                "queryStartDate": start_dt.strftime("%Y/%m/%d"),
+                "queryEndDate": end_dt.strftime("%Y/%m/%d"),
+                "commodityId": contract,
+            },
+        )
+        parsed = decode_and_parse_csv(body)
+        if parsed is None:
+            return (
+                f"查無契約 {contract} 在 {start_date}～{end_date} 的三大法人選擇權契約資料，"
+                f"請確認契約代碼是否正確；日期區間也可能超出資料保存範圍（約近 3 年內）"
+            )
+
+        _header, data_rows = parsed
+        lines = [
+            f"【三大法人選擇權契約歷史（CALL+PUT合計）】契約:{contract} 區間:{start_date}~{end_date}（共 {len(data_rows)} 筆）\n"
+        ]
+        for r in data_rows:
+            date, name, identity = r[0], r[1], r[2]
+            long_vol, long_amt = r[3], r[4]
+            short_vol, short_amt = r[5], r[6]
+            net_vol, net_amt = r[7], r[8]
+            oi_long, oi_short, oi_net = r[9], r[11], r[13]
+            lines.append(
+                f"{date} | {name} | {identity}\n"
+                f"  交易: 多 {long_vol}({long_amt}千元) / 空 {short_vol}({short_amt}千元) / 淨 {net_vol}({net_amt}千元)\n"
+                f"  未平倉: 多 {oi_long} / 空 {oi_short} / 淨 {oi_net}"
+            )
+
+        return "\n".join(lines)


### PR DESCRIPTION
## Summary

TAIFEX half of NEW_TOOLS_PLAN.md Tier 2 (#11-#13), completing Tier 2 alongside #56's TWSE half.

## New tools
- **`get_institutional_total_history`** — 三大法人期貨+選擇權合計總表 history (`totalTableDateDown`). `openapi.taifex.com.tw`'s `get_institutional_general` only returns the latest day; this accepts an arbitrary range, no span cap observed up to 3 months (capped client-side at 92 days per the established convention).
- **`get_institutional_fut_opt_split_history`** — futures vs options reported side by side per identity (`futAndOptDateDown`), so the two can be compared directly instead of only seeing them combined into one number. This data has **no equivalent anywhere on `openapi.taifex.com.tw`**. Confirmed the header/row shape at exactly 26 columns (futures = even indices, options = odd indices) via a precise `len()` check in Python — I miscounted by hand on the first pass and caught it before writing the tool, not after.
- **`get_options_institutional_by_contract_history`** — per-contract CALL+PUT combined totals (`optContractsDateDown`), distinct from #54's `get_options_institutional_calls_puts_history` which splits CALL vs PUT.

All three reuse the `fetch_bytes`/`decode_and_parse_csv`/`parse_yyyymmdd` helpers from `futures_daily_history.py` — no new infrastructure. No server-side span cap observed on any of the three (tested clean 3-month pulls each), still capped client-side at 92 days; retention verified to run out between 2023/06 and 2023/09, matching the other TAIFEX history tools from #49/#54.

## Test plan
- [x] `python -m py_compile` on all new/changed files
- [x] Booted the real `server.py` FastMCP instance and called all 3 tools live through `mcp._tool_manager.call_tool(...)` — verified real multi-day output, and spot-checked that `get_institutional_fut_opt_split_history`'s futures numbers match the raw CSV sample row captured during field discovery
- [x] Added 3 test classes to `tests/e2e/test_taifex_history_api.py` asserting column order/shape — 11 passed (full file)
- [x] Ran the full TAIFEX e2e suite (`test_taifex_api.py` + `test_taifex_batch2_api.py` + `test_taifex_new_api.py` + `test_taifex_history_api.py`) — 38 passed, no regressions
- [x] Total tool count: 172 → 175 as expected (this branch predates #56's merge, so it doesn't include those 5 yet)

This completes NEW_TOOLS_PLAN.md's Tier 1 and Tier 2 — marked all progress checkboxes done.