### PR TITLE
fix: restore missing 'import requests' and handle ChunkedEncodingError in fetch_or_skip

### DIFF
--- a/tests/e2e/test_taifex_new_api.py
+++ b/tests/e2e/test_taifex_new_api.py
@@ -1,6 +1,7 @@
 """測試新增的 TAIFEX API 工具端點。只驗證 tool 寫死的欄位存在，不驗證動態欄位。"""
 
 import pytest
+import requests
 from tests.helpers import fetch_or_skip
 
 HEADERS = {

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -7,7 +7,12 @@ from utils.api_client import TWSEAPIClient
 
 
 def fetch_or_skip(url: str, **kwargs):
-    """Fetch URL; skip test on upstream 5xx, empty body, or connection error. 404 still FAILs."""
+    """Fetch URL; skip test on upstream 5xx, empty body, or connection error. 404 still FAILs.
+
+    A response body that parses to valid-but-wrong JSON (renamed/missing/reordered fields)
+    is NOT skipped here — it's returned as-is so the caller's own field assertions run and
+    fail normally. Only genuinely transient conditions are skipped.
+    """
     try:
         return TWSEAPIClient.get_instance().fetch_json(url, **kwargs)
     except requests.HTTPError as e:
@@ -16,5 +21,15 @@ def fetch_or_skip(url: str, **kwargs):
         raise
     except requests.ConnectionError as e:
         pytest.skip(f"Cannot reach upstream: {url} — {e}")
+    except requests.exceptions.ChunkedEncodingError as e:
+        # Response stream cut off mid-transfer — a network-level failure, not a schema
+        # change, so always transient.
+        pytest.skip(f"Upstream connection dropped mid-response: {url} — {e}")
     except json.JSONDecodeError as e:
-        pytest.skip(f"Upstream returned empty/non-JSON body: {url} — {e}")
+        # Only skip on a genuinely empty body (upstream hiccup). A non-empty body that
+        # fails to parse (e.g. the endpoint started returning CSV/HTML instead of JSON —
+        # see issue #58 for a real occurrence) is a permanent format change, not a
+        # transient failure, so let it raise and fail the test instead of masking it.
+        if not (getattr(e, "doc", None) or "").strip():
+            pytest.skip(f"Upstream returned an empty body: {url} — {e}")
+        raise


### PR DESCRIPTION
## Summary

Two independent failures from the latest full-suite run, plus the fix proposed in #58.

### 1. `NameError: name 'requests' is not defined` in `test_taifex_new_api.py`

#38 removed this file's top-level `import requests` (its `_fetch()` no longer called `requests` directly after switching to `fetch_or_skip`). #55, merged around the same time, added `_fetch_large_traders_oi_futures()` to the same file, which calls `requests.get()` / `requests.exceptions.JSONDecodeError` directly (needed for the CSV fallback — it requires the raw response, not just parsed JSON). Neither PR could see the other's changes at review time, so the combination broke the moment both landed. Restored the import.

### 2. `ChunkedEncodingError: Response ended prematurely` in `test_otc_api.py`

`fetch_or_skip()` only catches `requests.ConnectionError` for network-level failures. Checked the actual MRO — `ChunkedEncodingError` does **not** subclass `ConnectionError`:
```
>>> issubclass(requests.exceptions.ChunkedEncodingError, requests.exceptions.ConnectionError)
False
```
So a truncated response stream (upstream cut the connection mid-transfer — unambiguously transient, not a schema signal) propagated as an uncaught failure instead of skipping like the other network-failure cases. Added it to the skip list.

### 3. #58's fix, applied while already touching this function

Narrowed the `JSONDecodeError` skip to only fire on a genuinely **empty** response body (checked via the exception's `.doc` attribute). A non-empty body that fails to parse — e.g. an endpoint that permanently switched from JSON to CSV, as literally happened with `OpenInterestOfLargeTradersFutures` in #55 — now raises and fails the test instead of being silently skipped. Closes #58.

## Test plan
- [x] `python -m py_compile` on both changed files
- [x] Unit-tested all three `fetch_or_skip` branches with mocked `TWSEAPIClient.fetch_json` calls: empty-body → skip, non-empty-unparseable-body → raise, `ChunkedEncodingError` → skip — all behaved as intended
- [x] Re-ran the two originally-failing tests live — both pass now
- [x] Ran the full `tests/e2e/` suite — 66 passed, 0 failures/errors