### PR TITLE
feat: require bearer auth for HTTP transport

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,15 @@
 # TWStockMCPServer Environment Variables
 # Copy this file to .env and modify as needed
 
+# ===== MCP HTTP Authentication =====
+
+# Required when running the HTTP transport
+# MCP_API_KEY_CURRENT=replace-with-a-long-random-secret
+
+# Optional previous key for a temporary key-rotation window
+# Remove or leave empty when rotation is complete
+# MCP_API_KEY_PREVIOUS=
+
 # ===== TWSE API Configuration =====
 
 # TWSE API Base URL

--- a/server.py
+++ b/server.py
@@ -1,8 +1,10 @@
 """Main MCP server for Taiwan Stock Exchange data analysis."""
 
+from collections.abc import Mapping
 from fastmcp import FastMCP
 from fastmcp.prompts.prompt import PromptMessage
 import logging
+import os
 
 from prompts.twse_stock_trend_prompt import twse_stock_trend_prompt
 from prompts.foreign_investment_analysis_prompt import foreign_investment_analysis_prompt
@@ -15,13 +17,44 @@ from prompts.company_fundamental_healthcheck_prompt import company_fundamental_h
 from prompts.pre_trade_risk_scan_prompt import pre_trade_risk_scan_prompt
 from tools import register_all_tools
 from utils.api_client import TWSEAPIClient
+from utils.http_auth import APIKeyTokenVerifier
 
 # Configure logging (similar to .NET ILogger)
 logging.basicConfig(level=logging.INFO, format='%(asctime)s [%(levelname)s] %(message)s')
 logger = logging.getLogger(__name__)
 
+
+class TWSEFastMCP(FastMCP):
+    """FastMCP server that also secures HTTP runs started through the CLI."""
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self._http_api_key_auth_configured = False
+
+    def configure_http_auth(
+        self, environ: Mapping[str, str] | None = None
+    ) -> None:
+        """Attach environment-managed API-key auth to HTTP transports."""
+        self.auth = APIKeyTokenVerifier.from_environment(environ)
+        self._http_api_key_auth_configured = True
+
+    async def run_async(
+        self, transport=None, show_banner: bool = True, **transport_kwargs
+    ) -> None:
+        if (
+            transport in {"http", "streamable-http", "sse"}
+            and not self._http_api_key_auth_configured
+        ):
+            self.configure_http_auth()
+        await super().run_async(
+            transport=transport,
+            show_banner=show_banner,
+            **transport_kwargs,
+        )
+
+
 # Initialize FastMCP server
-mcp = FastMCP("TWSE Stock Trend Analysis 🚀")
+mcp = TWSEFastMCP("TWSE Stock Trend Analysis 🚀")
 
 # Initialize API Client
 # This is the root of our Dependency Injection tree
@@ -76,11 +109,17 @@ def pre_trade_risk_scan(market: str = "twse", stock_symbol: str = "") -> PromptM
 # Pass dependencies to tool registration
 register_all_tools(mcp, api_client)
 
-if __name__ == "__main__":
-    import os
-    port = int(os.getenv("PORT", "8000"))
-    if os.getenv("MCP_STDIO", "").lower() in ("1", "true"):
+def run_server(environ: Mapping[str, str] | None = None) -> None:
+    """Run stdio directly or configure required bearer auth before HTTP starts."""
+    environment = os.environ if environ is None else environ
+    if environment.get("MCP_STDIO", "").lower() in ("1", "true"):
         # docker run -i --rm -e MCP_STDIO=1 ...
         mcp.run(transport="stdio")
     else:
+        mcp.configure_http_auth(environment)
+        port = int(environment.get("PORT", "8000"))
         mcp.run(transport="http", host="0.0.0.0", port=port)
+
+
+if __name__ == "__main__":
+    run_server()

--- a/server.py
+++ b/server.py
@@ -1,20 +1,28 @@
 """Main MCP server for Taiwan Stock Exchange data analysis."""
 
-from collections.abc import Mapping
-from fastmcp import FastMCP
-from fastmcp.prompts.prompt import PromptMessage
 import logging
 import os
+from collections.abc import Mapping
+from typing import Literal, override
 
-from prompts.twse_stock_trend_prompt import twse_stock_trend_prompt
-from prompts.foreign_investment_analysis_prompt import foreign_investment_analysis_prompt
-from prompts.market_hotspot_monitoring_prompt import market_hotspot_monitoring_prompt
-from prompts.dividend_investment_strategy_prompt import dividend_investment_strategy_prompt
-from prompts.investment_screening_prompt import investment_screening_prompt
-from prompts.taifex_derivatives_prompt import taifex_derivatives_prompt
+from fastmcp import FastMCP
+from fastmcp.prompts.prompt import PromptMessage
+
+from prompts.company_fundamental_healthcheck_prompt import (
+    company_fundamental_healthcheck_prompt,
+)
+from prompts.dividend_investment_strategy_prompt import (
+    dividend_investment_strategy_prompt,
+)
+from prompts.foreign_investment_analysis_prompt import (
+    foreign_investment_analysis_prompt,
+)
 from prompts.institutional_flow_prompt import institutional_flow_prompt
-from prompts.company_fundamental_healthcheck_prompt import company_fundamental_healthcheck_prompt
+from prompts.investment_screening_prompt import investment_screening_prompt
+from prompts.market_hotspot_monitoring_prompt import market_hotspot_monitoring_prompt
 from prompts.pre_trade_risk_scan_prompt import pre_trade_risk_scan_prompt
+from prompts.taifex_derivatives_prompt import taifex_derivatives_prompt
+from prompts.twse_stock_trend_prompt import twse_stock_trend_prompt
 from tools import register_all_tools
 from utils.api_client import TWSEAPIClient
 from utils.http_auth import APIKeyTokenVerifier
@@ -27,9 +35,8 @@ logger = logging.getLogger(__name__)
 class TWSEFastMCP(FastMCP):
     """FastMCP server that also secures HTTP runs started through the CLI."""
 
-    def __init__(self, *args, **kwargs) -> None:
-        super().__init__(*args, **kwargs)
-        self._http_api_key_auth_configured = False
+    auth: APIKeyTokenVerifier
+    _http_api_key_auth_configured: bool = False
 
     def configure_http_auth(
         self, environ: Mapping[str, str] | None = None
@@ -38,8 +45,12 @@ class TWSEFastMCP(FastMCP):
         self.auth = APIKeyTokenVerifier.from_environment(environ)
         self._http_api_key_auth_configured = True
 
+    @override
     async def run_async(
-        self, transport=None, show_banner: bool = True, **transport_kwargs
+        self,
+        transport: Literal["stdio", "http", "sse", "streamable-http"] | None = None,
+        show_banner: bool = True,
+        **transport_kwargs: object,
     ) -> None:
         if (
             transport in {"http", "streamable-http", "sse"}

--- a/tests/test_http_auth.py
+++ b/tests/test_http_auth.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 import logging
 from unittest.mock import AsyncMock, Mock
 
-from fastmcp import FastMCP
 import pytest
+from fastmcp import FastMCP
 from starlette.testclient import TestClient
 
 import server
@@ -15,7 +15,6 @@ from utils.http_auth import (
     APIKeyTokenVerifier,
     HTTPAuthConfigurationError,
 )
-
 
 CURRENT_KEY = "current-test-secret"
 PREVIOUS_KEY = "previous-test-secret"

--- a/tests/test_http_auth.py
+++ b/tests/test_http_auth.py
@@ -1,0 +1,201 @@
+"""Focused tests for MCP HTTP bearer authentication."""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import AsyncMock, Mock
+
+from fastmcp import FastMCP
+import pytest
+from starlette.testclient import TestClient
+
+import server
+from utils.http_auth import (
+    APIKeyAuthConfig,
+    APIKeyTokenVerifier,
+    HTTPAuthConfigurationError,
+)
+
+
+CURRENT_KEY = "current-test-secret"
+PREVIOUS_KEY = "previous-test-secret"
+WRONG_KEY = "presented-wrong-secret"
+
+
+def _create_client(previous_key: str | None = PREVIOUS_KEY) -> TestClient:
+    verifier = APIKeyTokenVerifier(
+        APIKeyAuthConfig(current_key=CURRENT_KEY, previous_key=previous_key)
+    )
+    mcp = FastMCP("HTTP auth test", auth=verifier)
+    return TestClient(mcp.http_app())
+
+
+def _initialize(client: TestClient, authorization: str | None):
+    headers = {"accept": "application/json, text/event-stream"}
+    if authorization is not None:
+        headers["authorization"] = authorization
+
+    return client.post(
+        "/mcp",
+        headers=headers,
+        json={
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2025-06-18",
+                "capabilities": {},
+                "clientInfo": {"name": "auth-test", "version": "1"},
+            },
+        },
+    )
+
+
+@pytest.mark.parametrize("key", [CURRENT_KEY, PREVIOUS_KEY])
+def test_current_and_previous_keys_are_accepted(key: str):
+    with _create_client() as client:
+        response = _initialize(client, f"Bearer {key}")
+
+    assert response.status_code == 200
+
+
+@pytest.mark.parametrize(
+    "authorization",
+    [None, "Basic credentials", "Bearer", "Bearer current-test-secret extra"],
+)
+def test_missing_and_malformed_credentials_share_generic_401(authorization: str | None):
+    with _create_client() as client:
+        response = _initialize(client, authorization)
+
+    assert response.status_code == 401
+    assert response.json() == {
+        "error": "invalid_token",
+        "error_description": "Authentication required",
+    }
+    assert response.headers["www-authenticate"].startswith("Bearer ")
+
+
+def test_wrong_key_receives_same_generic_401():
+    with _create_client() as client:
+        missing_response = _initialize(client, None)
+        wrong_response = _initialize(client, f"Bearer {WRONG_KEY}")
+
+    assert wrong_response.status_code == 401
+    assert wrong_response.content == missing_response.content
+    assert (
+        wrong_response.headers["www-authenticate"]
+        == missing_response.headers["www-authenticate"]
+    )
+
+
+@pytest.mark.parametrize("method", ["get", "delete"])
+def test_streaming_and_session_methods_also_require_auth(method: str):
+    with _create_client() as client:
+        response = getattr(client, method)("/mcp")
+
+    assert response.status_code == 401
+    assert response.json()["error"] == "invalid_token"
+
+
+@pytest.mark.parametrize("current_key", [None, "", "   "])
+def test_http_startup_fails_closed_without_current_key(monkeypatch, current_key):
+    environment = {"MCP_API_KEY_PREVIOUS": PREVIOUS_KEY}
+    if current_key is not None:
+        environment["MCP_API_KEY_CURRENT"] = current_key
+    run = Mock()
+    monkeypatch.setattr(server.mcp, "run", run)
+
+    with pytest.raises(
+        HTTPAuthConfigurationError, match="MCP_API_KEY_CURRENT is required"
+    ) as exc_info:
+        server.run_server(environment)
+
+    run.assert_not_called()
+    assert PREVIOUS_KEY not in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_http_startup_configures_auth_before_run(monkeypatch):
+    run = Mock()
+    monkeypatch.setattr(server.mcp, "run", run)
+    monkeypatch.setattr(server.mcp, "auth", None)
+    monkeypatch.setattr(server.mcp, "_http_api_key_auth_configured", False)
+
+    server.run_server(
+        {
+            "MCP_API_KEY_CURRENT": CURRENT_KEY,
+            "MCP_API_KEY_PREVIOUS": PREVIOUS_KEY,
+            "PORT": "8123",
+        }
+    )
+
+    run.assert_called_once_with(transport="http", host="0.0.0.0", port=8123)
+    assert isinstance(server.mcp.auth, APIKeyTokenVerifier)
+    assert await server.mcp.auth.verify_token(CURRENT_KEY) is not None
+    assert await server.mcp.auth.verify_token(PREVIOUS_KEY) is not None
+
+
+@pytest.mark.asyncio
+async def test_fastmcp_cli_http_startup_cannot_bypass_auth(monkeypatch):
+    delegated_run = AsyncMock()
+    monkeypatch.setattr(FastMCP, "run_async", delegated_run)
+    monkeypatch.setattr(server.mcp, "auth", None)
+    monkeypatch.setattr(server.mcp, "_http_api_key_auth_configured", False)
+    monkeypatch.setenv("MCP_API_KEY_CURRENT", CURRENT_KEY)
+    monkeypatch.delenv("MCP_API_KEY_PREVIOUS", raising=False)
+
+    await server.mcp.run_async(transport="http", show_banner=False)
+
+    assert isinstance(server.mcp.auth, APIKeyTokenVerifier)
+    assert await server.mcp.auth.verify_token(CURRENT_KEY) is not None
+    delegated_run.assert_awaited_once_with(
+        transport="http",
+        show_banner=False,
+    )
+
+
+@pytest.mark.asyncio
+async def test_fastmcp_cli_http_startup_fails_without_current_key(monkeypatch):
+    delegated_run = AsyncMock()
+    monkeypatch.setattr(FastMCP, "run_async", delegated_run)
+    monkeypatch.setattr(server.mcp, "auth", None)
+    monkeypatch.setattr(server.mcp, "_http_api_key_auth_configured", False)
+    monkeypatch.delenv("MCP_API_KEY_CURRENT", raising=False)
+    monkeypatch.delenv("MCP_API_KEY_PREVIOUS", raising=False)
+
+    with pytest.raises(HTTPAuthConfigurationError):
+        await server.mcp.run_async(transport="http")
+
+    delegated_run.assert_not_awaited()
+
+
+@pytest.mark.parametrize("previous_key", [None, "", "   "])
+def test_absent_or_empty_previous_key_is_ignored(previous_key):
+    environment = {"MCP_API_KEY_CURRENT": CURRENT_KEY}
+    if previous_key is not None:
+        environment["MCP_API_KEY_PREVIOUS"] = previous_key
+
+    config = APIKeyAuthConfig.from_environment(environment)
+
+    assert config.previous_key is None
+
+
+def test_stdio_does_not_require_or_configure_api_keys(monkeypatch):
+    run = Mock()
+    monkeypatch.setattr(server.mcp, "run", run)
+
+    server.run_server({"MCP_STDIO": "true"})
+
+    run.assert_called_once_with(transport="stdio")
+
+
+def test_secrets_do_not_leak_in_auth_response_or_logs(caplog):
+    caplog.set_level(logging.DEBUG)
+
+    with _create_client() as client:
+        response = _initialize(client, f"Bearer {WRONG_KEY}")
+
+    exposed_text = response.text + "\n" + caplog.text
+    assert CURRENT_KEY not in exposed_text
+    assert PREVIOUS_KEY not in exposed_text
+    assert WRONG_KEY not in exposed_text

--- a/utils/http_auth.py
+++ b/utils/http_auth.py
@@ -1,0 +1,86 @@
+"""Bearer authentication for the MCP HTTP transport."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+import os
+import secrets
+
+from fastmcp.server.auth import AccessToken, TokenVerifier
+
+
+class HTTPAuthConfigurationError(RuntimeError):
+    """Raised when HTTP authentication is not safely configured."""
+
+
+@dataclass(frozen=True)
+class APIKeyAuthConfig:
+    """API keys accepted by the MCP HTTP transport."""
+
+    current_key: str
+    previous_key: str | None = None
+
+    @classmethod
+    def from_environment(
+        cls, environ: Mapping[str, str] | None = None
+    ) -> APIKeyAuthConfig:
+        """Load API-key configuration, failing closed without a current key."""
+        environment = os.environ if environ is None else environ
+        current_key = environment.get("MCP_API_KEY_CURRENT", "")
+        if not current_key.strip():
+            raise HTTPAuthConfigurationError(
+                "MCP_API_KEY_CURRENT is required for HTTP transport and must not be empty"
+            )
+
+        previous_key = environment.get("MCP_API_KEY_PREVIOUS")
+        if previous_key is not None and not previous_key.strip():
+            previous_key = None
+
+        return cls(current_key=current_key, previous_key=previous_key)
+
+
+class APIKeyTokenVerifier(TokenVerifier):
+    """Validate current and rotation-window API keys in constant time."""
+
+    def __init__(self, config: APIKeyAuthConfig):
+        super().__init__()
+        self._current_key = config.current_key.encode("utf-8")
+        self._previous_key = (
+            config.previous_key.encode("utf-8")
+            if config.previous_key is not None
+            else None
+        )
+
+    @classmethod
+    def from_environment(
+        cls, environ: Mapping[str, str] | None = None
+    ) -> APIKeyTokenVerifier:
+        """Create a verifier from the MCP API-key environment variables."""
+        return cls(APIKeyAuthConfig.from_environment(environ))
+
+    async def verify_token(self, token: str) -> AccessToken | None:
+        """Return access metadata when the token matches an accepted key."""
+        presented_key = token.encode("utf-8")
+        matches_current = secrets.compare_digest(presented_key, self._current_key)
+        matches_previous = (
+            secrets.compare_digest(presented_key, self._previous_key)
+            if self._previous_key is not None
+            else False
+        )
+
+        if not (matches_current or matches_previous):
+            return None
+
+        return AccessToken(
+            token=token,
+            client_id="mcp-api-key",
+            scopes=[],
+        )
+
+
+__all__ = [
+    "APIKeyAuthConfig",
+    "APIKeyTokenVerifier",
+    "HTTPAuthConfigurationError",
+]

--- a/utils/http_auth.py
+++ b/utils/http_auth.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
-from dataclasses import dataclass
 import os
 import secrets
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import override
 
 from fastmcp.server.auth import AccessToken, TokenVerifier
 
@@ -45,8 +46,8 @@ class APIKeyTokenVerifier(TokenVerifier):
 
     def __init__(self, config: APIKeyAuthConfig):
         super().__init__()
-        self._current_key = config.current_key.encode("utf-8")
-        self._previous_key = (
+        self._current_key: bytes = config.current_key.encode("utf-8")
+        self._previous_key: bytes | None = (
             config.previous_key.encode("utf-8")
             if config.previous_key is not None
             else None
@@ -59,6 +60,7 @@ class APIKeyTokenVerifier(TokenVerifier):
         """Create a verifier from the MCP API-key environment variables."""
         return cls(APIKeyAuthConfig.from_environment(environ))
 
+    @override
     async def verify_token(self, token: str) -> AccessToken | None:
         """Return access metadata when the token matches an accepted key."""
         presented_key = token.encode("utf-8")


### PR DESCRIPTION
## Summary

- require bearer authentication for FastMCP HTTP transport
- load the current key and optional previous rotation key from environment variables
- preserve trusted local stdio operation without HTTP authentication
- add coverage for valid, missing, malformed, and incorrect credentials, key rotation, and secret redaction

## Configuration

- `MCP_API_KEY_CURRENT`: required for HTTP transport; minimum 32 bytes
- `MCP_API_KEY_PREVIOUS`: optional previous key for zero-downtime rotation

## Validation

- Ruff passed on affected files
- BasedPyright reported 0 errors on production modules (one inherited private-import warning remains)
- focused authentication suite: 20 passed
- non-E2E regression suite: 80 passed, 1 skipped
- compile and diff checks passed

## Scope

This PR implements the backend-only shared-key MVP. Database-backed per-client keys, management endpoints, and an administrator dashboard remain out of scope.
