### PR TITLE
fix: five silent data-correctness bugs found in a full-repo audit

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 TWStockMCPServer is a Model Context Protocol (MCP) server for Taiwan stock market data analysis. Built with FastMCP (Python) and `requests`. Data sources:
 - **TWSE OpenAPI** (`openapi.twse.com.tw`) — 143 tools: 公司治理、ESG、財報、交易、指數、券商
-- **TWSE Web API** (`twse.com.tw`) — 16 tools: 歷史日K、月均價、估值、融資融券（`/exchangeReport`）；三大法人買賣超日報、個股明細（`/rwd/zh/fund/T86`）；三大法人買賣金額、全市場收盤行情、市場成交量值、加權指數歷史、外資持股歷史（`/rwd/zh/...`，可查任意過去日期，與同名 openapi.twse.com.tw 端點僅回傳最近約12個交易日不同）；個股月/年成交彙總、鉅額交易明細（無伺服器端股票篩選，本地端過濾）、融券借券餘額/成交（`/rwd/zh/...`）（legacy JSON，非 Swagger）
+- **TWSE Web API** (`twse.com.tw`) — 16 tools: 歷史日K、月均價、融資融券（`/exchangeReport`）；估值（`/rwd/zh/afterTrading/BWIBBU_d` —— `/exchangeReport/BWIBBU_ALL` 會忽略 `date` 參數，只回最新交易日，不可用於歷史查詢）；三大法人買賣超日報、個股明細（`/rwd/zh/fund/T86`）；三大法人買賣金額、全市場收盤行情、市場成交量值、加權指數歷史、外資持股歷史（`/rwd/zh/...`，可查任意過去日期，與同名 openapi.twse.com.tw 端點僅回傳最近約12個交易日不同）；個股月/年成交彙總、鉅額交易明細（無伺服器端股票篩選，本地端過濾）、融券借券餘額/成交（`/rwd/zh/...`）（legacy JSON，非 Swagger）
 - **MIS 即時報價** (`mis.twse.com.tw`) — 1 tool: 盤中多股即時報價
 - **TPEx OpenAPI** (`tpex.org.tw/openapi`) — 3 tools: 上櫃日收盤、三大法人、本益比
 - **TAIFEX OpenAPI** (`openapi.taifex.com.tw`) — 16 tools: 三大法人系列、大額交易人部位、每日行情、選擇權分析（Delta/OI增減）、保證金、年月統計
@@ -49,7 +49,8 @@ tools/
 ├── company/                  # Company tools: basic_info, financials, esg, listing, news
 ├── trading/                  # Trading tools: daily, periodic, valuation, dividend_schedule, etf, market, warrants
 ├── market/                   # Market tools: indices, statistics, foreign
-├── history/                  # TWSE legacy: stock_day, stock_day_avg, bwibbu_all, margin_balance (exchangeReport); institutional (T86);
+├── history/                  # TWSE legacy: stock_day, stock_day_avg, margin_balance (exchangeReport); bwibbu_all (rwd/*);
+                              #   institutional (T86);
                               #   institutional_amounts, all_stocks_daily_close, market_turnover, taiex_index_history,
                               #   foreign_holdings_history, stock_monthly_yearly_history, block_trades_detail,
                               #   short_sale_lending (rwd/* endpoints — accept arbitrary past dates, unlike the

--- a/tests/e2e/test_company_financials_api.py
+++ b/tests/e2e/test_company_financials_api.py
@@ -1,0 +1,61 @@
+"""
+測試 company/financials.py 的產業別報表選擇邏輯。
+
+t187ap06/t187ap07 依產業切成六個端點變體（_ci/_fh/_basi/_bd/_ins/_mim），
+每家公司只會出現在其中一個。工具改為逐一探測而非讀 t187ap03_L 的「產業別」
+欄位——該欄位是數字代碼（'17' 同時涵蓋金控、銀行、證券、保險），無法據以四分。
+"""
+
+import pytest
+from tests.helpers import register_module_tools
+from utils.api_client import TWSEAPIClient
+import tools.company.financials as financials
+
+# 各產業一個代表，全部曾因舊的中文對照表而回傳空字串
+FINANCIAL_SECTOR_CODES = ["2884", "2891", "2801", "2855", "2850"]
+GENERAL_SECTOR_CODES = ["2330", "1101"]
+
+
+@pytest.fixture(scope="module")
+def financial_tools():
+    return register_module_tools(financials, TWSEAPIClient())
+
+
+@pytest.mark.parametrize("code", FINANCIAL_SECTOR_CODES + GENERAL_SECTOR_CODES)
+def test_income_statement_is_not_empty(financial_tools, code):
+    """非一般業公司也必須查得到損益表，不能落回 _ci 而回傳空字串."""
+    result = financial_tools["get_company_income_statement"](code)
+    assert result, f"{code} 的綜合損益表回傳空字串"
+    assert not result.startswith("查無"), f"{code} 的綜合損益表查無資料: {result}"
+
+
+@pytest.mark.parametrize("code", FINANCIAL_SECTOR_CODES + GENERAL_SECTOR_CODES)
+def test_balance_sheet_is_not_empty(financial_tools, code):
+    """資產負債表同上."""
+    result = financial_tools["get_company_balance_sheet"](code)
+    assert result, f"{code} 的資產負債表回傳空字串"
+    assert not result.startswith("查無"), f"{code} 的資產負債表查無資料: {result}"
+
+
+def test_unknown_code_returns_explicit_message(financial_tools):
+    """查無此公司時要回明確訊息，不能是無聲的空字串."""
+    result = financial_tools["get_company_income_statement"]("9999")
+    assert result.startswith("查無"), f"預期「查無」訊息，實際: {result!r}"
+
+
+def test_industry_variants_partition_companies():
+    """六個端點變體不重疊：若上游改成有交集，逐一探測的前提就不成立."""
+    client = TWSEAPIClient()
+    seen = {}
+    for suffix in financials.INDUSTRY_SUFFIXES:
+        data = client.fetch_data(f"/opendata/t187ap06_L{suffix}")
+        for item in data:
+            code = item.get("公司代號")
+            if not code:
+                continue
+            assert code not in seen, (
+                f"{code} 同時出現在 t187ap06_L{seen[code]} 與 t187ap06_L{suffix}，"
+                "端點不再互斥，探測順序會影響結果"
+            )
+            seen[code] = suffix
+    assert len(seen) > 900, f"上市公司總數異常偏低: {len(seen)}"

--- a/tests/e2e/test_history_api.py
+++ b/tests/e2e/test_history_api.py
@@ -44,24 +44,54 @@ class TestStockDayAPI:
 
 
 @pytest.fixture(scope="class")
-def bwibbu_all_data():
+def bwibbu_d_data():
     return fetch_or_skip(
-        "https://www.twse.com.tw/exchangeReport/BWIBBU_ALL",
-        params={"response": "json", "date": FIXED_DATE},
+        "https://www.twse.com.tw/rwd/zh/afterTrading/BWIBBU_d",
+        params={"response": "json", "date": FIXED_DATE, "selectType": "ALL"},
     )
 
 
-class TestBwibbuAllAPI:
-    """全市場估值 - BWIBBU_ALL
-    Tool get_market_valuation_by_date 使用 row[0]~row[4]:
-    代號、名稱、本益比、殖利率、股價淨值比。
+class TestBwibbuDailyAPI:
+    """全市場估值 - BWIBBU_d
+    Tool get_market_valuation_by_date 依 COL_* 常數取用欄位，
+    並以回應的 date 欄位確認拿到的確實是所查日期的資料。
     """
 
-    def test_row_has_stock_code_and_valuation_fields(self, bwibbu_all_data):
-        """tool 用 row[0] 作為代號篩選，row[2]~row[4] 作為估值欄位，需至少 5 欄."""
-        assert bwibbu_all_data.get("stat") == "OK"
-        first_row = bwibbu_all_data["data"][0]
-        assert len(first_row) >= 5, f"欄位數不足 5，row 結構可能已變更: {first_row}"
+    def test_field_order_matches_column_constants(self, bwibbu_d_data):
+        """tool 寫死欄位索引，需確認 fields 順序未變."""
+        assert bwibbu_d_data.get("stat") == "OK"
+        fields = bwibbu_d_data["fields"]
+        expected = [
+            "證券代號", "證券名稱", "收盤價", "殖利率(%)",
+            "股利年度", "本益比", "股價淨值比", "財報年/季",
+        ]
+        assert fields == expected, f"欄位順序異動！實際值: {fields}"
+
+    def test_response_echoes_requested_date(self, bwibbu_d_data):
+        """tool 靠 date 欄位擋掉「拿到別天資料卻標成所查日期」."""
+        assert bwibbu_d_data.get("date") == FIXED_DATE, (
+            f"回應日期 {bwibbu_d_data.get('date')} 與所查日期 {FIXED_DATE} 不符"
+        )
+
+    def test_endpoint_actually_honours_date(self):
+        """兩個不同日期必須回傳不同資料——舊的 BWIBBU_ALL 端點就是敗在這裡."""
+        other_date = "20240315"
+        other = fetch_or_skip(
+            "https://www.twse.com.tw/rwd/zh/afterTrading/BWIBBU_d",
+            params={"response": "json", "date": other_date, "selectType": "ALL"},
+        )
+        assert other.get("date") == other_date
+        assert other["data"][0] != _first_row_for(FIXED_DATE), (
+            "不同日期回傳相同資料，端點已不再支援歷史查詢"
+        )
+
+
+def _first_row_for(date: str):
+    resp = fetch_or_skip(
+        "https://www.twse.com.tw/rwd/zh/afterTrading/BWIBBU_d",
+        params={"response": "json", "date": date, "selectType": "ALL"},
+    )
+    return resp["data"][0]
 
 
 class TestMarginBalanceAPI:

--- a/tests/e2e/test_output_limits.py
+++ b/tests/e2e/test_output_limits.py
@@ -1,0 +1,76 @@
+"""
+測試清單型工具的輸出上限。
+
+這些工具原本把整份資料 join 成單一字串回傳，實測 get_warrant_basic_info 產出
+37.85 MB、get_warrant_yearly_issuance_statistics 8.18M 字元、
+get_options_daily_history 指定 contract_month 後仍有 2.65 MB——遠超任何模型的
+context window。此處以「字元數天花板」為斷言，避免日後有人拿掉分頁。
+"""
+
+import pytest
+
+from utils.api_client import TWSEAPIClient
+from tests.helpers import register_module_tools
+import tools.trading.warrants as warrants
+import tools.history.margin_balance as margin_balance
+import tools.history.bwibbu_all as bwibbu_all
+
+# 寬鬆的上限：只要沒有分頁就會超出好幾個數量級，不必抓得太緊
+MAX_CHARS = 100_000
+
+TRADING_DATE = "20250102"
+
+
+@pytest.fixture(scope="module")
+def client():
+    return TWSEAPIClient()
+
+
+@pytest.mark.parametrize(
+    "tool_name",
+    [
+        "get_warrant_basic_info",
+        "get_warrant_daily_trading",
+        "get_warrant_yearly_issuance_statistics",
+    ],
+)
+def test_warrant_list_tools_are_bounded(client, tool_name):
+    """權證三支清單工具不指定 code 時仍須分頁."""
+    tools = register_module_tools(warrants, client)
+    result = tools[tool_name]()
+    assert len(result) < MAX_CHARS, f"{tool_name} 輸出 {len(result):,} 字元，未分頁"
+    assert "共有" in result and "筆" in result, "應回報總筆數"
+
+
+def test_warrant_pagination_advances(client):
+    """offset 必須真的換頁."""
+    tools = register_module_tools(warrants, client)
+    first = tools["get_warrant_basic_info"](limit=5)
+    second = tools["get_warrant_basic_info"](limit=5, offset=5)
+    assert first != second, "offset 未生效，兩頁內容相同"
+
+
+def test_margin_balance_is_bounded(client):
+    tools = register_module_tools(margin_balance, client)
+    result = tools["get_margin_balance"](TRADING_DATE)
+    assert len(result) < MAX_CHARS, f"輸出 {len(result):,} 字元，未分頁"
+    assert "offset=" in result, "未提示如何取得後續資料"
+
+
+def test_margin_balance_offset_out_of_range_is_explicit(client):
+    tools = register_module_tools(margin_balance, client)
+    result = tools["get_margin_balance"](TRADING_DATE, offset=999_999)
+    assert "超出範圍" in result, f"offset 越界未給明確訊息: {result[:120]!r}"
+
+
+def test_market_valuation_is_bounded(client):
+    tools = register_module_tools(bwibbu_all, client)
+    result = tools["get_market_valuation_by_date"](TRADING_DATE)
+    assert len(result) < MAX_CHARS, f"輸出 {len(result):,} 字元，未分頁"
+    assert "offset=" in result, "未提示如何取得後續資料"
+
+
+def test_market_valuation_offset_out_of_range_is_explicit(client):
+    tools = register_module_tools(bwibbu_all, client)
+    result = tools["get_market_valuation_by_date"](TRADING_DATE, offset=999_999)
+    assert "超出範圍" in result, f"offset 越界未給明確訊息: {result[:120]!r}"

--- a/tests/e2e/test_summary_row_filtering.py
+++ b/tests/e2e/test_summary_row_filtering.py
@@ -1,0 +1,105 @@
+"""
+測試彙總列與空殼佔位物件不會被當成一般資料列。
+
+TWSE 的 BFIAUU / TWT93U / TWTASU 都在 data 陣列末尾附一列全市場加總
+（「總計」/「合計」），欄位結構與明細列完全相同。原本三個工具都沒過濾，
+筆數多算一筆，且清單中會出現一筆量值為全市場加總的假交易
+（實測 20260827：鉅額交易顯示 40 筆，其中末列量 27,681,085 是 39 筆真實
+成交的總和，為真實最大單筆 8,059,880 的 3.4 倍）。
+
+MIS 則是對前綴錯誤或不存在的代號回傳佔位物件 {"c": "", "z": "-", ...}，
+留著會讓筆數灌水，並讓「查無報價」的訊息永遠不可達。
+"""
+
+import pytest
+
+from utils.api_client import TWSEAPIClient
+from utils.constants import SUMMARY_ROW_LABELS
+from tests.helpers import fetch_or_skip, register_module_tools
+import tools.history.block_trades_detail as block_trades_detail
+import tools.history.short_sale_lending as short_sale_lending
+import tools.realtime.stock_info as stock_info
+
+TRADING_DATE = "20250102"
+
+
+@pytest.fixture(scope="module")
+def client():
+    return TWSEAPIClient()
+
+
+class TestUpstreamStillAppendsSummaryRow:
+    """先確認上游仍然附彙總列——若哪天不附了，下面的過濾就成了無效程式碼."""
+
+    def test_bfiauu_last_row_is_summary(self):
+        resp = fetch_or_skip(
+            "https://www.twse.com.tw/rwd/zh/block/BFIAUU",
+            params={"response": "json", "date": TRADING_DATE},
+        )
+        assert resp["data"][-1][0].strip() in SUMMARY_ROW_LABELS
+
+    def test_twt93u_last_row_is_summary(self):
+        resp = fetch_or_skip(
+            "https://www.twse.com.tw/rwd/zh/marginTrading/TWT93U",
+            params={"response": "json", "date": TRADING_DATE, "selectType": "ALL"},
+        )
+        assert resp["data"][-1][1].strip() in SUMMARY_ROW_LABELS
+
+    def test_twtasu_last_row_is_summary(self):
+        resp = fetch_or_skip(
+            "https://www.twse.com.tw/rwd/zh/afterTrading/TWTASU",
+            params={"response": "json", "date": TRADING_DATE},
+        )
+        assert resp["data"][-1][0].split(None, 1)[0] in SUMMARY_ROW_LABELS
+
+
+class TestToolsExcludeSummaryRow:
+    def test_block_trades_excludes_summary(self, client):
+        tools = register_module_tools(block_trades_detail, client)
+        result = tools["get_block_trades_detail"](TRADING_DATE, limit=1000)
+        for label in SUMMARY_ROW_LABELS:
+            assert label not in result, f"輸出仍含彙總列「{label}」"
+
+    def test_block_trades_count_excludes_summary(self, client):
+        """筆數要少於 API 原始列數，且不能把彙總列算進去."""
+        resp = fetch_or_skip(
+            "https://www.twse.com.tw/rwd/zh/block/BFIAUU",
+            params={"response": "json", "date": TRADING_DATE},
+        )
+        raw_rows = len(resp["data"])
+        tools = register_module_tools(block_trades_detail, client)
+        result = tools["get_block_trades_detail"](TRADING_DATE)
+        assert f"共 {raw_rows - 1} 筆" in result, (
+            f"筆數未扣除彙總列（API {raw_rows} 列）：{result.splitlines()[0]}"
+        )
+
+    def test_lending_balance_excludes_summary(self, client):
+        tools = register_module_tools(short_sale_lending, client)
+        result = tools["get_short_sale_lending_balance_history"](TRADING_DATE, limit=2000)
+        assert "合計" not in result
+
+    def test_lending_trades_excludes_summary(self, client):
+        tools = register_module_tools(short_sale_lending, client)
+        result = tools["get_short_sale_lending_trades_history"](TRADING_DATE, limit=2000)
+        assert "合計" not in result
+
+    def test_lending_trades_summary_is_not_a_stock_code(self, client):
+        """「合計」曾被 split 當成股票代號，用它查詢應回查無而非命中."""
+        tools = register_module_tools(short_sale_lending, client)
+        result = tools["get_short_sale_lending_trades_history"](TRADING_DATE, stock_no="合計")
+        assert result.startswith("查無"), f"「合計」仍被當成股票代號: {result[:100]!r}"
+
+
+class TestRealtimeQuoteExcludesPlaceholders:
+    def test_unknown_code_reports_no_data(self, client):
+        """不存在的代號應回「查無」，而非「共 N 支」加一列空殼."""
+        tools = register_module_tools(stock_info, client)
+        result = tools["get_realtime_quote"](["9999"])
+        assert result.startswith("查無"), f"預期查無資料，實際: {result[:120]!r}"
+
+    def test_count_matches_real_quotes(self, client):
+        """一支上市加一支上櫃應為 2 支：上市查詢回的空殼不得計入."""
+        tools = register_module_tools(stock_info, client)
+        result = tools["get_realtime_quote"](["2330", "6547"])
+        assert "（共 2 支）" in result, f"筆數含空殼: {result.splitlines()[0]!r}"
+        assert "? [" not in result, "輸出含代號為空的佔位列"

--- a/tests/e2e/test_taifex_history_api.py
+++ b/tests/e2e/test_taifex_history_api.py
@@ -256,3 +256,37 @@ class TestInstitutionalFutOptSplitHistoryAPI:
         assert header[0] == "日期" and header[1] == "身份別", f"前兩欄異動: {header[:2]}"
         assert "期貨" in header[2] and "選擇權" in header[3], f"欄位2/3應為期貨/選擇權多方交易口數: {header[2:4]}"
         assert "期貨" in header[22] and "選擇權" in header[23], f"欄位22/23應為期貨/選擇權多空未平倉口數淨額: {header[22:24]}"
+
+
+class TestHistoryOutputLimits:
+    """歷史下載類工具的輸出上限。
+
+    這兩支從 www.taifex.com.tw 下載多日 CSV，沒有伺服器端分頁。
+    get_options_daily_history 原本的保護帶了 `not contract_month`，
+    而 docstring 又建議指定 contract_month——正好把呼叫者推進唯一沒有保護的
+    分支（實測單月 TXO 單一到期月仍有 23,032 列 / 2.65 MB）。
+    """
+
+    MAX_CHARS = 100_000
+
+    def test_options_daily_history_is_bounded_with_contract_month(self):
+        from utils.api_client import TWSEAPIClient
+        from tests.helpers import register_module_tools
+        import tools.taifex.options_daily_history as module
+
+        tools = register_module_tools(module, TWSEAPIClient())
+        result = tools["get_options_daily_history"](
+            "20250602", "20250630", "TXO", contract_month="202507"
+        )
+        assert len(result) < self.MAX_CHARS, f"輸出 {len(result):,} 字元，未設上限"
+
+    def test_institutional_futures_history_is_bounded(self):
+        from utils.api_client import TWSEAPIClient
+        from tests.helpers import register_module_tools
+        import tools.taifex.institutional_futures_history as module
+
+        tools = register_module_tools(module, TWSEAPIClient())
+        result = tools["get_institutional_traders_by_futures_history"](
+            "20250401", "20250630", ""
+        )
+        assert len(result) < self.MAX_CHARS, f"輸出 {len(result):,} 字元，未設上限"

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -33,3 +33,37 @@ def fetch_or_skip(url: str, **kwargs):
         if not (getattr(e, "doc", None) or "").strip():
             pytest.skip(f"Upstream returned an empty body: {url} — {e}")
         raise
+
+
+class _CapturingMCP:
+    """Minimal stand-in for FastMCP that records the functions modules register.
+
+    ``register_tools`` only ever needs ``.tool`` — either bare (``@mcp.tool``) or
+    called with keywords (``mcp.tool(name=..., description=...)``). Capturing the
+    undecorated callables lets tests exercise a tool end-to-end without spinning
+    up a server.
+    """
+
+    def __init__(self):
+        self.tools = {}
+
+    def tool(self, *args, **kwargs):
+        if args and callable(args[0]):
+            fn = args[0]
+            self.tools[fn.__name__] = fn
+            return fn
+
+        name = kwargs.get("name")
+
+        def decorator(fn):
+            self.tools[name or fn.__name__] = fn
+            return fn
+
+        return decorator
+
+
+def register_module_tools(module, client=None):
+    """Register ``module``'s tools against a capturing MCP and return {name: fn}."""
+    mcp = _CapturingMCP()
+    module.register_tools(mcp, client or TWSEAPIClient.get_instance())
+    return mcp.tools

--- a/tests/test_api_client_errors.py
+++ b/tests/test_api_client_errors.py
@@ -1,0 +1,88 @@
+"""
+測試上游故障不會被偽裝成「查無資料」。
+
+fetch_company_data / fetch_latest_market_data 曾經把所有例外吞掉並回傳
+None / []，導致 timeout、5xx、維護頁與「這家公司真的沒這筆資料」在工具輸出上
+完全相同——@handle_api_errors 因此永遠不會觸發，MSG_QUERY_FAILED 形同死碼。
+"""
+
+import pytest
+import requests
+
+from utils.api_client import TWSEAPIClient
+from utils.tool_factory import create_company_tool
+from tests.helpers import _CapturingMCP
+
+ENDPOINT = "/opendata/t187ap06_L_ci"
+
+
+class _MaintenancePage:
+    """200 OK，但 body 是 HTML 而非 JSON（TWSE 維護時的實際行為）."""
+
+    status_code = 200
+    text = "<html>系統維護中</html>"
+    content = b"<html>"
+
+    def raise_for_status(self):
+        pass
+
+    def json(self):
+        raise ValueError("Expecting value: line 1 column 1 (char 0)")
+
+
+def _raise(exc):
+    def _fake(*args, **kwargs):
+        raise exc
+
+    return _fake
+
+
+UPSTREAM_FAILURES = [
+    pytest.param(_raise(requests.exceptions.Timeout("timed out")), id="timeout"),
+    pytest.param(_raise(requests.exceptions.ConnectionError("refused")), id="connection-error"),
+    pytest.param(_raise(requests.exceptions.HTTPError("503 Server Error")), id="http-503"),
+    pytest.param(lambda *a, **kw: _MaintenancePage(), id="html-instead-of-json"),
+]
+
+
+@pytest.fixture
+def client():
+    # cache_ttl=0：確保每個測試都真的打一次（被 monkeypatch 攔下）而非讀到快取
+    return TWSEAPIClient(cache_ttl=0)
+
+
+@pytest.mark.parametrize("fake_request", UPSTREAM_FAILURES)
+def test_fetch_company_data_propagates_failures(monkeypatch, client, fake_request):
+    """故障必須往上拋，不能降級成 None（等同「查無此公司」）."""
+    monkeypatch.setattr(requests, "request", fake_request)
+    with pytest.raises(Exception):
+        client.fetch_company_data(ENDPOINT, "2330")
+
+
+@pytest.mark.parametrize("fake_request", UPSTREAM_FAILURES)
+def test_fetch_latest_market_data_propagates_failures(monkeypatch, client, fake_request):
+    """同上，不能降級成 []（等同「今天沒有行情」）."""
+    monkeypatch.setattr(requests, "request", fake_request)
+    with pytest.raises(Exception):
+        client.fetch_latest_market_data("/exchangeReport/MI_INDEX")
+
+
+@pytest.mark.parametrize("fake_request", UPSTREAM_FAILURES)
+def test_tool_reports_failure_not_missing_data(monkeypatch, client, fake_request):
+    """工具層輸出必須是「查詢失敗」，而非與查無資料無從分辨的空字串."""
+    mcp = _CapturingMCP()
+    create_company_tool(mcp, ENDPOINT, "probe_tool", "測試用", client)
+    monkeypatch.setattr(requests, "request", fake_request)
+
+    result = mcp.tools["probe_tool"]("2330")
+    assert result.startswith("查詢失敗"), f"故障被偽裝成正常回應: {result!r}"
+
+
+def test_missing_company_still_reads_as_missing(client):
+    """對照組：真的查無此公司時，訊息要與「查詢失敗」明確區分."""
+    mcp = _CapturingMCP()
+    create_company_tool(mcp, ENDPOINT, "probe_tool", "測試用", client)
+
+    result = mcp.tools["probe_tool"]("9999")
+    assert result.startswith("查無"), f"預期「查無」訊息，實際: {result!r}"
+    assert not result.startswith("查詢失敗")

--- a/tests/tool_field_dependencies.py
+++ b/tests/tool_field_dependencies.py
@@ -72,7 +72,8 @@ TOOL_REQUIRED_FIELDS: Dict[str, List[str]] = {
     "/opendata/t187ap35_L": ["公司代號", "公司名稱", "召開股東會日期", "提案內容", "股東依公司法第172條之1行使提案權-提案受理期間"],
     "/opendata/t187ap38_L": ["公司代號", "公司名稱"],
     "/opendata/t187ap41_L": ["公司代號", "公司名稱", "是否採電子投票", "股東常(臨時)會", "開會地點", "開會日期"],
-    "/static/20151104/CSR103": ["公司代號", "公司名稱"],
+    # /static/20151104/CSR103 已由 TWSE 下架（302 → /404.html），不再回傳 JSON，
+    # 無欄位可驗；get_companies_with_csr_reports_103 已改為回覆來源不存在。
 
     # --- company/listing.py ---
     "/company/applylistingForeign": ["ApplicationDate", "ApprovedDate", "Code", "Company", "ListingDate"],

--- a/tests/tool_field_dependencies.py
+++ b/tests/tool_field_dependencies.py
@@ -81,7 +81,6 @@ TOOL_REQUIRED_FIELDS: Dict[str, List[str]] = {
     "/company/suspendListingCsvAndHtml": ["Code", "Company", "DelistingDate"],
 
     # --- company/financials.py ---
-    "/opendata/t187ap03_L": ["產業別"],
     "/opendata/t187ap17_L": [
         "出表日期", "年度", "季別", "公司代號", "公司名稱",
         "營業收入(百萬元)",

--- a/tools/company/basic_info.py
+++ b/tools/company/basic_info.py
@@ -240,12 +240,20 @@ def register_tools(mcp: FastMCP, client: Optional[TWSEAPIClient] = None) -> None
             limit: 回傳筆數上限（預設 50）
             offset: 跳過前 N 筆（預設 0，搭配 limit 分頁）
         """
-        data = _client.fetch_data("/static/20151104/CSR103")
+        # TWSE 已下架這份 2015 年的靜態資料集：端點回 302 導向自家 /404.html。
+        # 這裡是唯一保留在地捕捉的地方——來源確定不存在，而非暫時故障，
+        # 回一句「查詢失敗」對使用者沒有幫助，不如直接指路。其餘端點一律讓
+        # 例外往上傳，避免故障被偽裝成查無資料。
+        unavailable = (
+            "查無 103 年度 CSR 報告名單：來源端點已由 TWSE 下架（轉址至 404）。\n"
+            "建議改查近年永續報告（ESG）相關端點，或至公司官網/公告查詢。"
+        )
+        try:
+            data = _client.fetch_data("/static/20151104/CSR103")
+        except ValueError:
+            return unavailable
         if not data:
-            return (
-                "查無 103 年度 CSR 報告名單或資料格式不符（來源可能為舊式靜態頁）。\n"
-                "建議改查近年永續報告（ESG）相關端點，或至公司官網/公告查詢。"
-            )
+            return unavailable
 
         valid = [it for it in data if isinstance(it, dict) and has_meaningful_data(it, ["公司代號", "公司名稱"])]
         if not valid:

--- a/tools/company/financials.py
+++ b/tools/company/financials.py
@@ -2,7 +2,18 @@
 
 from typing import Optional
 from fastmcp import FastMCP
-from utils import TWSEAPIClient, handle_api_errors, format_properties_with_values_multiline, create_company_tool
+from utils import (
+    TWSEAPIClient,
+    handle_api_errors,
+    format_properties_with_values_multiline,
+    create_company_tool,
+    MSG_NO_DATA_FOR_CODE,
+)
+
+# Industry-specific report variants of t187ap06/t187ap07. They partition the
+# universe of companies, so a company appears in exactly one of them. '_ci'
+# (一般業) holds the overwhelming majority and is probed first.
+INDUSTRY_SUFFIXES = ("_ci", "_fh", "_basi", "_bd", "_ins", "_mim")
 
 # Simple tools: fetch_company_data(endpoint, code) → format as properties.
 SIMPLE_FINANCIAL_TOOLS = [
@@ -27,28 +38,20 @@ def register_tools(mcp: FastMCP, client: Optional[TWSEAPIClient] = None) -> None
     for endpoint, name, doc in SIMPLE_FINANCIAL_TOOLS:
         create_company_tool(mcp, endpoint, name, doc, client)
 
-    def _get_industry_api_suffix(code: str) -> str:
-        """Return API suffix for the company's industry; defaults to '_ci'."""
-        try:
-            profile_data = _client.fetch_company_data("/opendata/t187ap03_L", code)
-            if not profile_data:
-                return "_ci"
+    def _fetch_industry_report(prefix: str, code: str):
+        """Fetch an industry-specific report by probing each endpoint variant.
 
-            industry = profile_data.get("產業別", "")
-            industry_mapping = {
-                "金融業": "_basi",
-                "證券期貨業": "_bd",
-                "金控業": "_fh",
-                "保險業": "_ins",
-                "異業": "_mim",
-                "一般業": "_ci",
-            }
-            for key, suffix in industry_mapping.items():
-                if key in industry or industry == key:
-                    return suffix
-            return "_ci"
-        except Exception:
-            return "_ci"
+        The 產業別 field of t187ap03_L cannot drive this choice: it holds a numeric
+        code (e.g. '17' covers 金控, 銀行, 證券 and 保險 alike), and it is absent
+        entirely for 公發公司. Probing is exact instead — the variants partition all
+        companies, so the first endpoint containing ``code`` is the right format.
+        Each variant is cached by fetch_data, so repeat lookups cost no extra requests.
+        """
+        for suffix in INDUSTRY_SUFFIXES:
+            data = _client.fetch_company_data(f"{prefix}{suffix}", code)
+            if data:
+                return data
+        return None
 
     # --- Tools that need industry-specific endpoints ---
 
@@ -58,9 +61,10 @@ def register_tools(mcp: FastMCP, client: Optional[TWSEAPIClient] = None) -> None
         """根據股票代號查詢上市公司綜合損益表。
         自動偵測公司所屬產業並使用對應的財務報表格式（一般業、金融業、證券期貨業、金控業、保險業、異業）。
         """
-        suffix = _get_industry_api_suffix(code)
-        data = _client.fetch_company_data(f"/opendata/t187ap06_L{suffix}", code)
-        return format_properties_with_values_multiline(data) if data else ""
+        data = _fetch_industry_report("/opendata/t187ap06_L", code)
+        if not data:
+            return MSG_NO_DATA_FOR_CODE.format(query_target=f"公司代號 {code}", data_type="綜合損益表")
+        return format_properties_with_values_multiline(data)
 
     @mcp.tool
     @handle_api_errors(use_code_param=True)
@@ -68,9 +72,10 @@ def register_tools(mcp: FastMCP, client: Optional[TWSEAPIClient] = None) -> None
         """根據股票代號查詢上市公司資產負債表。
         自動偵測公司所屬產業並使用對應的財務報表格式（一般業、金融業、證券期貨業、金控業、保險業、異業）。
         """
-        suffix = _get_industry_api_suffix(code)
-        data = _client.fetch_company_data(f"/opendata/t187ap07_L{suffix}", code)
-        return format_properties_with_values_multiline(data) if data else ""
+        data = _fetch_industry_report("/opendata/t187ap07_L", code)
+        if not data:
+            return MSG_NO_DATA_FOR_CODE.format(query_target=f"公司代號 {code}", data_type="資產負債表")
+        return format_properties_with_values_multiline(data)
 
     @mcp.tool
     @handle_api_errors(use_code_param=True)
@@ -78,9 +83,10 @@ def register_tools(mcp: FastMCP, client: Optional[TWSEAPIClient] = None) -> None
         """根據股票代號查詢公開發行公司資產負債表。
         自動偵測公司所屬產業並使用對應的財務報表格式。
         """
-        suffix = _get_industry_api_suffix(code)
-        data = _client.fetch_company_data(f"/opendata/t187ap07_X{suffix}", code)
-        return format_properties_with_values_multiline(data) if data else ""
+        data = _fetch_industry_report("/opendata/t187ap07_X", code)
+        if not data:
+            return MSG_NO_DATA_FOR_CODE.format(query_target=f"公司代號 {code}", data_type="資產負債表")
+        return format_properties_with_values_multiline(data)
 
     @mcp.tool
     @handle_api_errors(use_code_param=True)
@@ -88,9 +94,10 @@ def register_tools(mcp: FastMCP, client: Optional[TWSEAPIClient] = None) -> None
         """根據股票代號查詢公開發行公司綜合損益表。
         自動偵測公司所屬產業並使用對應的財務報表格式。
         """
-        suffix = _get_industry_api_suffix(code)
-        data = _client.fetch_company_data(f"/opendata/t187ap06_X{suffix}", code)
-        return format_properties_with_values_multiline(data) if data else ""
+        data = _fetch_industry_report("/opendata/t187ap06_X", code)
+        if not data:
+            return MSG_NO_DATA_FOR_CODE.format(query_target=f"公司代號 {code}", data_type="綜合損益表")
+        return format_properties_with_values_multiline(data)
 
     # --- Tool with custom sorting/pagination ---
 

--- a/tools/history/block_trades_detail.py
+++ b/tools/history/block_trades_detail.py
@@ -2,7 +2,7 @@
 
 from typing import Optional
 from fastmcp import FastMCP
-from utils import TWSEAPIClient, handle_api_errors, DEFAULT_DISPLAY_LIMIT
+from utils import TWSEAPIClient, handle_api_errors, DEFAULT_DISPLAY_LIMIT, SUMMARY_ROW_LABELS
 
 BFIAUU_URL = "https://www.twse.com.tw/rwd/zh/block/BFIAUU"
 
@@ -39,6 +39,9 @@ def register_tools(mcp: FastMCP, client: Optional[TWSEAPIClient] = None) -> None
             return f"查無 {date} 的鉅額交易資料，請確認該日期為交易日（非假日或週末）"
 
         data = resp.get("data", [])
+        # 末列是全市場「總計」，其量/金額為當日所有鉅額交易的加總，與明細列同構。
+        # 留著會讓筆數多一筆，並在清單中出現一筆遠大於真實最大單筆的假交易。
+        data = [row for row in data if row and row[0].strip() not in SUMMARY_ROW_LABELS]
         if not data:
             return f"查無 {date} 的鉅額交易資料"
 

--- a/tools/history/bwibbu_all.py
+++ b/tools/history/bwibbu_all.py
@@ -4,7 +4,14 @@ from typing import Optional
 from fastmcp import FastMCP
 from utils import TWSEAPIClient, handle_api_errors
 
-BWIBBU_ALL_URL = "https://www.twse.com.tw/exchangeReport/BWIBBU_ALL"
+# rwd/zh/afterTrading/BWIBBU_d honours the `date` parameter and echoes it back.
+# The older /exchangeReport/BWIBBU_ALL silently ignores `date` entirely — every
+# request returns the latest trading day — so it cannot serve historical queries.
+BWIBBU_D_URL = "https://www.twse.com.tw/rwd/zh/afterTrading/BWIBBU_d"
+
+# Column order of BWIBBU_d's `data` rows, per its `fields` array:
+# ['證券代號', '證券名稱', '收盤價', '殖利率(%)', '股利年度', '本益比', '股價淨值比', '財報年/季']
+COL_CODE, COL_NAME, COL_CLOSE, COL_YIELD, COL_PE, COL_PB = 0, 1, 2, 3, 5, 6
 
 
 def register_tools(mcp: FastMCP, client: Optional[TWSEAPIClient] = None) -> None:
@@ -23,15 +30,25 @@ def register_tools(mcp: FastMCP, client: Optional[TWSEAPIClient] = None) -> None
             stock_no: 股票代號（選填），若指定則只回傳該股票的估值資料
 
         Returns:
-            每支股票的代號、名稱、本益比、殖利率(%)、股價淨值比
+            每支股票的代號、名稱、收盤價、本益比、殖利率(%)、股價淨值比
         """
         resp = _client.fetch_json(
-            BWIBBU_ALL_URL,
-            params={"response": "json", "date": date},
+            BWIBBU_D_URL,
+            params={"response": "json", "date": date, "selectType": "ALL"},
         )
 
         if not resp or resp.get("stat") != "OK":
-            return f"查無 {date} 的估值資料，請確認該日期為交易日（非假日或週末）"
+            reason = (resp or {}).get("stat") or "請確認該日期為交易日（非假日或週末）"
+            return f"查無 {date} 的估值資料：{reason}"
+
+        # The endpoint echoes back the date it actually served. Never relabel a
+        # different day's data with the requested date.
+        served_date = resp.get("date") or date
+        if served_date != date:
+            return (
+                f"查無 {date} 的估值資料，來源實際回傳的是 {served_date} 的資料，"
+                f"請改用 {served_date} 查詢，或確認 {date} 為交易日。"
+            )
 
         data = resp.get("data", [])
         if not data:
@@ -39,19 +56,22 @@ def register_tools(mcp: FastMCP, client: Optional[TWSEAPIClient] = None) -> None
 
         # Filter by stock_no if specified
         if stock_no:
-            data = [row for row in data if row[0].strip() == stock_no]
+            data = [row for row in data if row[COL_CODE].strip() == stock_no]
             if not data:
                 return f"查無股票代號 {stock_no} 在 {date} 的估值資料"
 
-        lines = [f"【全市場估值資料 - {date}】（共 {len(data)} 筆）\n"]
+        title = resp.get("title") or f"全市場估值資料 - {date}"
+        lines = [f"【{title}】（共 {len(data)} 筆）\n"]
 
         for row in data:
-            # row: [股票代號, 名稱, 本益比, 殖利率(%), 股價淨值比]
-            code = row[0].strip()
-            name = row[1].strip()
-            pe = row[2] if row[2] else "-"
-            dy = row[3] if row[3] else "-"
-            pb = row[4] if row[4] else "-"
-            lines.append(f"{code} {name} | 本益比: {pe} | 殖利率: {dy}% | 股價淨值比: {pb}")
+            code = row[COL_CODE].strip()
+            name = row[COL_NAME].strip()
+            close = row[COL_CLOSE] or "-"
+            dy = row[COL_YIELD] or "-"
+            pe = row[COL_PE] or "-"
+            pb = row[COL_PB] or "-"
+            lines.append(
+                f"{code} {name} | 收盤價: {close} | 本益比: {pe} | 殖利率: {dy}% | 股價淨值比: {pb}"
+            )
 
         return "\n".join(lines)

--- a/tools/history/bwibbu_all.py
+++ b/tools/history/bwibbu_all.py
@@ -2,7 +2,7 @@
 
 from typing import Optional
 from fastmcp import FastMCP
-from utils import TWSEAPIClient, handle_api_errors
+from utils import TWSEAPIClient, handle_api_errors, DEFAULT_DISPLAY_LIMIT
 
 # rwd/zh/afterTrading/BWIBBU_d honours the `date` parameter and echoes it back.
 # The older /exchangeReport/BWIBBU_ALL silently ignores `date` entirely — every
@@ -20,7 +20,8 @@ def register_tools(mcp: FastMCP, client: Optional[TWSEAPIClient] = None) -> None
 
     @mcp.tool
     @handle_api_errors()
-    def get_market_valuation_by_date(date: str, stock_no: str = "") -> str:
+    def get_market_valuation_by_date(date: str, stock_no: str = "",
+                                     limit: int = DEFAULT_DISPLAY_LIMIT, offset: int = 0) -> str:
         """查詢全市場上市股票的本益比（P/E）、殖利率、股價淨值比（P/B）。
         適合用於篩選低估值個股或比較產業估值水位。
         可指定特定股票代號只查單一個股。
@@ -28,6 +29,8 @@ def register_tools(mcp: FastMCP, client: Optional[TWSEAPIClient] = None) -> None
         Args:
             date: 查詢日期 YYYYMMDD，回傳該日的估值資料
             stock_no: 股票代號（選填），若指定則只回傳該股票的估值資料
+            limit: 回傳筆數上限（預設 50）。全市場逾 1000 檔，未分頁的完整輸出逾 60KB
+            offset: 跳過前 N 筆（預設 0，搭配 limit 分頁）
 
         Returns:
             每支股票的代號、名稱、收盤價、本益比、殖利率(%)、股價淨值比
@@ -60,10 +63,16 @@ def register_tools(mcp: FastMCP, client: Optional[TWSEAPIClient] = None) -> None
             if not data:
                 return f"查無股票代號 {stock_no} 在 {date} 的估值資料"
 
-        title = resp.get("title") or f"全市場估值資料 - {date}"
-        lines = [f"【{title}】（共 {len(data)} 筆）\n"]
+        total = len(data)
+        page = data[offset:offset + limit]
+        if not page:
+            return f"offset={offset} 已超出範圍，{date} 的估值資料共 {total} 筆"
 
-        for row in data:
+        title = resp.get("title") or f"全市場估值資料 - {date}"
+        page_note = f"，顯示第 {offset + 1}–{offset + len(page)} 筆" if total > len(page) else ""
+        lines = [f"【{title}】（共 {total} 筆{page_note}）\n"]
+
+        for row in page:
             code = row[COL_CODE].strip()
             name = row[COL_NAME].strip()
             close = row[COL_CLOSE] or "-"
@@ -73,5 +82,9 @@ def register_tools(mcp: FastMCP, client: Optional[TWSEAPIClient] = None) -> None
             lines.append(
                 f"{code} {name} | 收盤價: {close} | 本益比: {pe} | 殖利率: {dy}% | 股價淨值比: {pb}"
             )
+
+        remaining = total - offset - len(page)
+        if remaining > 0:
+            lines.append(f"\n... 還有 {remaining} 筆，使用 offset={offset + limit} 查看更多")
 
         return "\n".join(lines)

--- a/tools/history/margin_balance.py
+++ b/tools/history/margin_balance.py
@@ -3,7 +3,7 @@
 from datetime import datetime, timedelta
 from typing import Optional
 from fastmcp import FastMCP
-from utils import TWSEAPIClient, handle_api_errors
+from utils import TWSEAPIClient, handle_api_errors, DEFAULT_DISPLAY_LIMIT
 
 MI_MARGN_URL = "https://www.twse.com.tw/exchangeReport/MI_MARGN"
 MAX_RETRY_DAYS = 7
@@ -15,7 +15,8 @@ def register_tools(mcp: FastMCP, client: Optional[TWSEAPIClient] = None) -> None
 
     @mcp.tool
     @handle_api_errors()
-    def get_margin_balance(date: str, stock_no: str = "") -> str:
+    def get_margin_balance(date: str, stock_no: str = "",
+                           limit: int = DEFAULT_DISPLAY_LIMIT, offset: int = 0) -> str:
         """查詢全市場融資融券餘額，用於判斷市場槓桿水位與多空情緒。
         若指定日期非交易日，會自動往前尋找最近的交易日資料。
         可指定特定股票代號只查單一個股。
@@ -23,6 +24,8 @@ def register_tools(mcp: FastMCP, client: Optional[TWSEAPIClient] = None) -> None
         Args:
             date: 查詢日期 YYYYMMDD
             stock_no: 股票代號（選填），若指定則只回傳該股票的融資融券資料
+            limit: 回傳筆數上限（預設 50）。全市場約 1300 檔，未分頁的完整輸出逾 100KB
+            offset: 跳過前 N 筆（預設 0，搭配 limit 分頁）
 
         Returns:
             每支股票的融資買進、賣出、餘額、融券賣出、買進、餘額、資券互抵等資料
@@ -63,13 +66,23 @@ def register_tools(mcp: FastMCP, client: Optional[TWSEAPIClient] = None) -> None
             if not data:
                 return f"查無股票代號 {stock_no} 在 {actual_date} 的融資融券資料"
 
+        total = len(data)
+        page = data[offset:offset + limit]
+        if not page:
+            return f"offset={offset} 已超出範圍，{actual_date} 的融資融券資料共 {total} 筆"
+
         date_note = f"（原查詢 {date}，實際資料日 {actual_date}）" if actual_date != date else ""
-        lines = [f"【融資融券餘額 - {actual_date}】{date_note}（共 {len(data)} 筆）\n"]
+        page_note = f"，顯示第 {offset + 1}–{offset + len(page)} 筆" if total > len(page) else ""
+        lines = [f"【融資融券餘額 - {actual_date}】{date_note}（共 {total} 筆{page_note}）\n"]
 
         if fields:
             lines.append("欄位: " + " | ".join(fields) + "\n")
 
-        for row in data:
+        for row in page:
             lines.append(" | ".join(str(cell) for cell in row))
+
+        remaining = total - offset - len(page)
+        if remaining > 0:
+            lines.append(f"\n... 還有 {remaining} 筆，使用 offset={offset + limit} 查看更多")
 
         return "\n".join(lines)

--- a/tools/history/short_sale_lending.py
+++ b/tools/history/short_sale_lending.py
@@ -6,7 +6,7 @@ cover the securities-lending (借券) side of short selling.
 
 from typing import Optional
 from fastmcp import FastMCP
-from utils import TWSEAPIClient, handle_api_errors, DEFAULT_DISPLAY_LIMIT
+from utils import TWSEAPIClient, handle_api_errors, DEFAULT_DISPLAY_LIMIT, SUMMARY_ROW_LABELS
 
 TWT93U_URL = "https://www.twse.com.tw/rwd/zh/marginTrading/TWT93U"
 TWTASU_URL = "https://www.twse.com.tw/rwd/zh/afterTrading/TWTASU"
@@ -43,6 +43,8 @@ def register_tools(mcp: FastMCP, client: Optional[TWSEAPIClient] = None) -> None
             return f"查無 {date} 的信用額度總量管制餘額資料，請確認該日期為交易日（非假日或週末）"
 
         data = resp.get("data", [])
+        # TWT93U 的末列是全市場「合計」：代號欄為空、名稱欄為「合計」
+        data = [row for row in data if row and row[1].strip() not in SUMMARY_ROW_LABELS]
         if not data:
             return f"查無 {date} 的信用額度總量管制餘額資料"
 
@@ -118,6 +120,9 @@ def register_tools(mcp: FastMCP, client: Optional[TWSEAPIClient] = None) -> None
         for row in data:
             code_name = row[0].split(None, 1)
             code = code_name[0] if code_name else ""
+            # TWTASU 的末列 row[0] 就是「合計」，split 會把它當成股票代號
+            if code in SUMMARY_ROW_LABELS:
+                continue
             sname = code_name[1].strip() if len(code_name) > 1 else ""
             parsed.append((code, sname, row))
 

--- a/tools/realtime/stock_info.py
+++ b/tools/realtime/stock_info.py
@@ -39,7 +39,10 @@ def register_tools(mcp: FastMCP, client: Optional[TWSEAPIClient] = None) -> None
         ex_ch = "|".join(ex_ch_parts)
         resp = _client.fetch_json(MIS_URL, params={"ex_ch": ex_ch, "json": 1, "delay": 0})
 
-        msg_array = resp.get("msgArray", [])
+        # MIS 對前綴錯誤或不存在的代號不是略過，而是回一個佔位物件
+        # {"c": "", "n": null, "z": "-", ...}。留著會讓筆數灌水並印出一列空殼，
+        # 也會讓下方「查無報價」的訊息永遠不可達（msgArray 恆非空）。
+        msg_array = [item for item in resp.get("msgArray", []) if item.get("c")]
 
         # Check for stocks that returned no data (might be OTC)
         found_codes = {item.get("c") for item in msg_array if item.get("z") != "-" or item.get("y")}
@@ -51,7 +54,7 @@ def register_tools(mcp: FastMCP, client: Optional[TWSEAPIClient] = None) -> None
             otc_resp = _client.fetch_json(
                 MIS_URL, params={"ex_ch": "|".join(otc_parts), "json": 1, "delay": 0}
             )
-            otc_array = otc_resp.get("msgArray", [])
+            otc_array = [item for item in otc_resp.get("msgArray", []) if item.get("c")]
             msg_array.extend(otc_array)
 
         if not msg_array:

--- a/tools/taifex/institutional_futures_history.py
+++ b/tools/taifex/institutional_futures_history.py
@@ -7,7 +7,7 @@ www.taifex.com.tw's HTML-form download endpoint, which genuinely accepts an arbi
 
 from typing import Optional
 from fastmcp import FastMCP
-from utils import TWSEAPIClient, handle_api_errors
+from utils import TWSEAPIClient, handle_api_errors, cap_rows
 from .futures_position import TAIFEX_HEADERS
 from .futures_daily_history import parse_yyyymmdd, decode_and_parse_csv
 
@@ -17,6 +17,9 @@ FUT_CONTRACTS_DATE_DOWN_URL = "https://www.taifex.com.tw/cht/3/futContractsDateD
 # ~3 rows/trading-day/contract (dealer/investment trust/foreign), so cap client-side to keep
 # tool output manageable.
 MAX_SPAN_DAYS = 92
+# Ceiling on rows written to the response. A 92-day span with no contract filter
+# returns ~4,300 rows, each rendered as three lines.
+MAX_OUTPUT_ROWS = 300
 
 
 def register_tools(mcp: FastMCP, client: Optional[TWSEAPIClient] = None) -> None:
@@ -72,10 +75,15 @@ def register_tools(mcp: FastMCP, client: Optional[TWSEAPIClient] = None) -> None
             )
 
         _header, data_rows = parsed
+        total = len(data_rows)
+        shown_rows, cap_note = cap_rows(
+            data_rows, MAX_OUTPUT_ROWS, "請縮小 start_date～end_date 或指定 contract"
+        )
         lines = [
-            f"【三大法人期貨部位歷史】契約:{contract_label} 區間:{start_date}~{end_date}（共 {len(data_rows)} 筆）\n"
+            f"【三大法人期貨部位歷史】契約:{contract_label} 區間:{start_date}~{end_date}"
+            f"（共 {total} 筆{cap_note}）\n"
         ]
-        for r in data_rows:
+        for r in shown_rows:
             date, name, identity = r[0], r[1], r[2]
             long_vol, long_amt = r[3], r[4]
             short_vol, short_amt = r[5], r[6]

--- a/tools/taifex/options_daily_history.py
+++ b/tools/taifex/options_daily_history.py
@@ -2,7 +2,7 @@
 
 from typing import Optional
 from fastmcp import FastMCP
-from utils import TWSEAPIClient, handle_api_errors
+from utils import TWSEAPIClient, handle_api_errors, cap_rows
 from .futures_position import TAIFEX_HEADERS
 from .futures_daily_history import parse_yyyymmdd, decode_and_parse_csv
 
@@ -17,7 +17,11 @@ from .futures_daily_history import parse_yyyymmdd, decode_and_parse_csv
 OPT_DATA_DOWN_URL = "https://www.taifex.com.tw/cht/3/optDataDown"
 
 MAX_SPAN_DAYS = 31
-ROW_LIMIT_WITHOUT_MONTH_FILTER = 300
+# Ceiling on rows written to the response. Applied on every path: narrowing to a
+# single contract_month still returns ~23,000 rows (~2.6 MB) for a month of TXO,
+# and the month-listing branch below never sees those because it only fires when
+# contract_month is empty.
+MAX_OUTPUT_ROWS = 300
 
 
 def register_tools(mcp: FastMCP, client: Optional[TWSEAPIClient] = None) -> None:
@@ -80,7 +84,7 @@ def register_tools(mcp: FastMCP, client: Optional[TWSEAPIClient] = None) -> None
         if call_put:
             data_rows = [r for r in data_rows if r[4] == call_put]
 
-        if not contract_month and len(data_rows) > ROW_LIMIT_WITHOUT_MONTH_FILTER:
+        if not contract_month and len(data_rows) > MAX_OUTPUT_ROWS:
             months = sorted(set(r[2].strip() for r in data_rows))
             return (
                 f"契約 {contract} 在 {start_date}～{end_date} 共有 {len(data_rows)} 筆資料，"
@@ -92,11 +96,15 @@ def register_tools(mcp: FastMCP, client: Optional[TWSEAPIClient] = None) -> None
         if not data_rows:
             return f"查無契約 {contract} 在 {start_date}～{end_date}（到期月份:{contract_month or '全部'}）的選擇權行情資料"
 
+        total = len(data_rows)
+        shown_rows, cap_note = cap_rows(
+            data_rows, MAX_OUTPUT_ROWS, "請縮小 start_date～end_date，或加上 contract_month／call_put"
+        )
         lines = [
             f"【選擇權每日OHLC歷史行情】契約:{contract} 到期月份:{contract_month or '全部'} "
-            f"區間:{start_date}~{end_date}（共 {len(data_rows)} 筆）\n"
+            f"區間:{start_date}~{end_date}（共 {total} 筆{cap_note}）\n"
         ]
-        for r in data_rows:
+        for r in shown_rows:
             date, month, strike, cp = r[0], r[2].strip(), r[3], r[4]
             o, h, l, c = r[5], r[6], r[7], r[8]
             vol, settle, oi, session = r[9], r[10], r[11], r[17]

--- a/tools/trading/warrants.py
+++ b/tools/trading/warrants.py
@@ -2,7 +2,25 @@
 
 from typing import Optional
 from fastmcp import FastMCP
-from utils import TWSEAPIClient, handle_api_errors, format_multiple_records, format_properties_with_values_multiline
+from utils import (
+    TWSEAPIClient,
+    handle_api_errors,
+    format_list_response,
+    format_multiple_records,
+    format_properties_with_values_multiline,
+    DEFAULT_DISPLAY_LIMIT,
+)
+
+
+def _format_warrant_summary(item) -> str:
+    """One-line summary of a warrant, omitting the verbose 備註 changelog."""
+    return (
+        f"- {item.get('權證代號', 'N/A')} {item.get('權證簡稱', 'N/A')}"
+        f" | {item.get('權證類型', 'N/A')}/{item.get('類別', 'N/A')}"
+        f" | 標的: {item.get('標的證券/指數', 'N/A')}"
+        f" | 最新履約價: {item.get('最新履約價格(元)/履約指數', 'N/A')}"
+        f" | 最後交易日: {item.get('最後交易日', 'N/A')}\n"
+    )
 
 
 def register_tools(mcp: FastMCP, client: Optional[TWSEAPIClient] = None) -> None:
@@ -11,33 +29,42 @@ def register_tools(mcp: FastMCP, client: Optional[TWSEAPIClient] = None) -> None
 
     @mcp.tool
     @handle_api_errors()
-    def get_warrant_basic_info(code: str = "") -> str:
+    def get_warrant_basic_info(code: str = "", limit: int = DEFAULT_DISPLAY_LIMIT, offset: int = 0) -> str:
         """查詢上市權證基本資料彙總表。
 
         Args:
             code: 權證代號（選填）。若指定則只回傳該權證資料。
+            limit: 未指定 code 時的回傳筆數上限（預設 50）
+            offset: 未指定 code 時跳過前 N 筆（預設 0，搭配 limit 分頁）
         """
         if code:
             data = _client.fetch_company_data("/opendata/t187ap37_L", code)
             return format_properties_with_values_multiline(data) if data else ""
-        else:
-            data = _client.fetch_data("/opendata/t187ap37_L") 
-            return format_multiple_records(data) if data else ""
+
+        # 近 4 萬檔權證，全數展開約 40 MB，必須分頁。清單模式另外省略「備註」——
+        # 該欄位是逐筆的增額/註銷流水帳，單筆可逾千字，佔了輸出的絕大部分。
+        # 指定 code 時仍回傳完整欄位。
+        data = _client.fetch_data("/opendata/t187ap37_L")
+        return format_list_response(
+            data, "上市權證基本資料", formatter=_format_warrant_summary, limit=limit, offset=offset
+        )
 
     @mcp.tool
     @handle_api_errors()
-    def get_warrant_daily_trading(code: str = "") -> str:
+    def get_warrant_daily_trading(code: str = "", limit: int = DEFAULT_DISPLAY_LIMIT, offset: int = 0) -> str:
         """查詢上市認購(售)權證每日成交資料檔。
 
         Args:
             code: 權證代號（選填）。若指定則只回傳該權證成交資料。
+            limit: 未指定 code 時的回傳筆數上限（預設 50）
+            offset: 未指定 code 時跳過前 N 筆（預設 0，搭配 limit 分頁）
         """
         if code:
             data = _client.fetch_company_data("/opendata/t187ap42_L", code)
             return format_properties_with_values_multiline(data) if data else ""
-        else:
-            data = _client.fetch_data("/opendata/t187ap42_L")
-            return format_multiple_records(data) if data else ""
+
+        data = _client.fetch_data("/opendata/t187ap42_L")
+        return format_list_response(data, "上市權證每日成交資料", limit=limit, offset=offset)
 
     @mcp.tool
     @handle_api_errors()
@@ -48,7 +75,12 @@ def register_tools(mcp: FastMCP, client: Optional[TWSEAPIClient] = None) -> None
 
     @mcp.tool
     @handle_api_errors()
-    def get_warrant_yearly_issuance_statistics() -> str:
-        """查詢上市認購(售)權證年度發行量概況統計表。"""
+    def get_warrant_yearly_issuance_statistics(limit: int = DEFAULT_DISPLAY_LIMIT, offset: int = 0) -> str:
+        """查詢上市認購(售)權證年度發行量概況統計表。
+
+        Args:
+            limit: 回傳筆數上限（預設 50）
+            offset: 跳過前 N 筆（預設 0，搭配 limit 分頁）
+        """
         data = _client.fetch_data("/opendata/t187ap36_L")
-        return format_multiple_records(data) if data else ""
+        return format_list_response(data, "上市權證年度發行量統計", limit=limit, offset=offset)

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -9,6 +9,7 @@ from .constants import (
     MSG_QUERY_FAILED,
     MSG_NO_DATA_FOR_CODE,
     MSG_TOTAL_RECORDS,
+    SUMMARY_ROW_LABELS,
 )
 from .decorators import handle_api_errors
 from .formatters import (
@@ -38,6 +39,7 @@ __all__ = [
     "MSG_QUERY_FAILED",
     "MSG_NO_DATA_FOR_CODE",
     "MSG_TOTAL_RECORDS",
+    "SUMMARY_ROW_LABELS",
     "handle_api_errors",
     "format_properties_with_values_multiline",
     "format_multiple_records",

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -21,6 +21,7 @@ from .formatters import (
     format_list_response,
     create_simple_list_formatter,
     truncate,
+    cap_rows,
 )
 from .tool_factory import create_company_tool, create_list_tool
 from .date_helper import roc_to_ad, ad_to_roc
@@ -47,6 +48,7 @@ __all__ = [
     "format_list_response",
     "create_simple_list_formatter",
     "truncate",
+    "cap_rows",
     "create_company_tool",
     "create_list_tool",
     "roc_to_ad",

--- a/utils/api_client.py
+++ b/utils/api_client.py
@@ -92,8 +92,12 @@ class TWSEAPIClient:
             try:
                 data = resp.json()
             except Exception as parse_err:
-                logger.warning(f"Response is not valid JSON for {url}: {parse_err}; returning empty list")
-                return []
+                # TWSE serves an HTML maintenance page on some outages. Returning []
+                # here would render that as "this endpoint has no data" — a false
+                # negative indistinguishable from a genuinely empty result.
+                raise ValueError(
+                    f"回應不是合法 JSON（來源可能正在維護）: {url}"
+                ) from parse_err
             result = data if isinstance(data, list) else ([data] if data else [])
             if self.cache_ttl > 0:
                 self._cache[url] = (time.time(), result)
@@ -103,30 +107,34 @@ class TWSEAPIClient:
             raise
 
     def fetch_company_data(self, endpoint: str, code: str, timeout: float = APIConfig.DEFAULT_TIMEOUT) -> Optional[TWSEDataItem]:
-        """Instance method to fetch company data."""
-        try:
-            data = self.fetch_data(endpoint, timeout)
-            filtered_data = [
-                item for item in data
-                if isinstance(item, dict) and (
-                    item.get("公司代號") == code or
-                    item.get("Code") == code or
-                    item.get("權證代號") == code
-                )
-            ]
-            return filtered_data[0] if filtered_data else None
-        except Exception as e:
-            logger.error(f"Failed to fetch company data for {code}: {e}")
-            return None
+        """Fetch one company's record from a list endpoint, or None if absent.
+
+        Failures propagate deliberately. ``None`` means "this endpoint has no row
+        for ``code``" and nothing else; swallowing timeouts, 5xx or maintenance
+        pages here would collapse "the API is down" into that same ``None`` and
+        make every caller report a confident false negative. Callers are tools
+        wrapped in ``@handle_api_errors``, which turns the exception into
+        ``MSG_QUERY_FAILED``.
+        """
+        data = self.fetch_data(endpoint, timeout)
+        filtered_data = [
+            item for item in data
+            if isinstance(item, dict) and (
+                item.get("公司代號") == code or
+                item.get("Code") == code or
+                item.get("權證代號") == code
+            )
+        ]
+        return filtered_data[0] if filtered_data else None
 
     def fetch_latest_market_data(self, endpoint: str, count: Optional[int] = None, timeout: float = APIConfig.DEFAULT_TIMEOUT) -> List[TWSEDataItem]:
-        """Instance method to fetch latest market data."""
-        try:
-            data = self.fetch_data(endpoint, timeout)
-            return data[-count:] if data and count is not None else data
-        except Exception as e:
-            logger.error(f"Failed to fetch latest market data: {e}")
-            return []
+        """Fetch the trailing ``count`` records of a list endpoint.
+
+        As with ``fetch_company_data``, failures propagate rather than degrading
+        to an empty list — an empty list is a factual claim about the market data.
+        """
+        data = self.fetch_data(endpoint, timeout)
+        return data[-count:] if data and count is not None else data
 
     def fetch_json(self, url: str, params: Optional[Dict[str, Any]] = None, timeout: float = APIConfig.DEFAULT_TIMEOUT, headers: Optional[Dict[str, str]] = None) -> Any:
         """Fetch raw JSON from an arbitrary full URL (not base_url-relative).

--- a/utils/constants.py
+++ b/utils/constants.py
@@ -12,3 +12,9 @@ MSG_NO_DATA_FOR_CODE = "查無{query_target}的{data_type}"
 
 # Success messages
 MSG_TOTAL_RECORDS = "共有 {count} 筆{data_type}："
+
+# TWSE legacy endpoints append a market-wide summary row to the per-stock `data`
+# array (BFIAUU 的「總計」、TWT93U/TWTASU 的「合計」). It is not a security and must
+# not be counted or rendered as one — its 量/金額 是全市場加總，與明細列同構，
+# 混進清單會讓下游把它當成一筆真實成交。
+SUMMARY_ROW_LABELS = ("總計", "合計")

--- a/utils/formatters.py
+++ b/utils/formatters.py
@@ -1,6 +1,6 @@
 """Data formatting utilities."""
 
-from typing import List, Union, Sequence
+from typing import Any, List, Union, Sequence
 from .constants import MSG_TOTAL_RECORDS, DEFAULT_DISPLAY_LIMIT
 from .types import TWSEDataItem, DataFormatter
 
@@ -204,3 +204,15 @@ def create_simple_list_formatter(
         return result + "\n"
     
     return formatter
+
+def cap_rows(rows: List[Any], limit: int, hint: str = "請縮小查詢範圍") -> tuple[List[Any], str]:
+    """Cap ``rows`` at ``limit`` and return the kept rows plus a header note.
+
+    For row-oriented (list-of-list) sources that have no server-side paging —
+    TAIFEX's CSV downloads, TWSE's legacy `tables` payloads — where dumping every
+    row would produce a multi-megabyte string. The note is empty when nothing was
+    dropped, so callers can append it unconditionally.
+    """
+    if len(rows) <= limit:
+        return rows, ""
+    return rows[:limit], f"，僅顯示前 {limit} 筆（{hint}）"

--- a/utils/tool_factory.py
+++ b/utils/tool_factory.py
@@ -5,6 +5,7 @@ from fastmcp import FastMCP
 from utils import (
     TWSEAPIClient,
     MSG_NO_DATA,
+    MSG_NO_DATA_FOR_CODE,
     DEFAULT_DISPLAY_LIMIT,
     format_list_response,
     format_properties_with_values_multiline,
@@ -12,7 +13,14 @@ from utils import (
 from utils.decorators import handle_api_errors
 from utils.types import DataFormatter
 
-def create_company_tool(mcp: FastMCP, endpoint: str, name: str, docstring: str, client: Optional[TWSEAPIClient] = None) -> Callable[[str], str]:
+def create_company_tool(
+    mcp: FastMCP,
+    endpoint: str,
+    name: str,
+    docstring: str,
+    client: Optional[TWSEAPIClient] = None,
+    empty_data_type: str = "資料",
+) -> Callable[[str], str]:
     """
     Create and register a standard company data query tool.
 
@@ -22,6 +30,7 @@ def create_company_tool(mcp: FastMCP, endpoint: str, name: str, docstring: str, 
         name: Function name for the tool
         docstring: Tool description
         client: TWSEAPIClient instance for dependency injection
+        empty_data_type: Noun used in the "查無…" message when the company has no row
 
     Returns:
         The registered tool function
@@ -30,7 +39,11 @@ def create_company_tool(mcp: FastMCP, endpoint: str, name: str, docstring: str, 
 
     def tool_fn(code: str) -> str:
         data = _client.fetch_company_data(endpoint, code)
-        return format_properties_with_values_multiline(data) if data else ""
+        if not data:
+            return MSG_NO_DATA_FOR_CODE.format(
+                query_target=f"公司代號 {code}", data_type=empty_data_type
+            )
+        return format_properties_with_values_multiline(data)
 
     tool_fn.__name__ = name
     decorated = handle_api_errors(use_code_param=True)(tool_fn)


### PR DESCRIPTION
Five independent correctness bugs found by auditing the repo. All five are silent — none of them raise, and four of them return output that reads as a normal, confident answer. One commit each.

- 8b9081a — financial statements were empty for every financial-sector company. _get_industry_api_suffix() matched t187ap03_L's 產業別 against Chinese industry names, but the field holds a two-digit numeric code (2884 = '17', 2330 = '24', 1101 = '01' — 33 distinct values across all 1,095 listed companies, never any Chinese text). The mapping never matched, so it always fell through to _ci, which is disjoint from _fh/_basi/_bd/_ins/_mim. Every financial holding, bank, broker and insurer (2884, 2891, 2801, 2855, 2850…) got an empty string from get_company_income_statement / get_company_balance_sheet. The field can't drive this decision at all — 金控/銀行/證券/保險 all share '17', and 公發公司 aren't in t187ap03_L — so this now probes the six variants instead. They partition all companies, and fetch_data already caches per endpoint.
- d7eae4a — historical valuations returned today's data under the requested date's label. /exchangeReport/BWIBBU_ALL ignores date entirely: date=20250102 and date=20260827 return byte-identical payloads. The tool then printed 【全市場估值資料 - 20250102】 over 2026-08-27 figures. The response's own date/title would have exposed this, but only data was read — which also left both "查無資料" guards unreachable. Switched to /rwd/zh/afterTrading/BWIBBU_d, which honours date. Note its field order differs, so the column indices moved to COL_* constants; swapping the URL alone would have read the wrong columns.
- 562a4d9 — a TWSE outage read as "this company has no such data" across 50+ tools. fetch_company_data / fetch_latest_market_data caught every exception and returned None / [], so @handle_api_errors never fired and MSG_QUERY_FAILED was dead code for that whole family. Fault injection (timeout, connection refused, HTTP 503, HTML maintenance p all four cases: an empty string from the 42create_company_tool tools, and 查無股票代號 2330 的日成交資訊 — an actively asserted false negative — from the rest. Both try/except blocks dropped; all 21 call sites are already inside the decorator.
- 4d85690 — list tools returned multi-megabyte strings. Measinfo() 39,268 rows → 37.85 MB,get_warrant_yearly_issuance_statistics() 8.2M chars (with no parameters at all to narrow it), get_warrant_daily_trading() 3.6M, get_margin_balance() 114K, get_market_valuation_by_date() 52K. get_options_daily_history guarded with not contract_month and len(rows) > N while its docstring urges callers to pass contract_month — steering them into the only unguarded branch (one month of TXO under a single contract_month still returns 2.65 MB).
- 4b283f0 — summary rows and placeholder quotes counted as real data. BFIAUU/TWT93U/TWTASU each append a market-wide total structurally identical to
  the detail rows. get_block_trades_detail reported "共 40  real trades and rendered 總計 as a trade at 3.4× the largestgenuine one. TWTASU splits code and name out of one padded string, so 合計 became a stock code that stock_no="合計" matched. Separately, MIS returns {"c": "", "z": "-"} for unknown codes rather than omitting them, inflating counts and leaving 查無…即時報價資料 unreachable — querying 9999
  returned "共 1 支" plus a hollow row.

Two of these were surfaced by the others rather than found directly: 562a4d9 exposed that /static/20151104/CSR103 has been taken down by TWSE (302 to
its own /404.html) — fetch_data's silent [] had been making tayed green over a dead endpoint.

Test plan

- [x] Confirmed each bug reproduces before the fix, against the live APIs — not inferred from reading the code
- [x] 8b9081a: 2884/2891/2801/2855/2850 return real reports (2884 now gets the 金控 format with 利息淨收益 etc.); 2330/1101 unchanged; unknown codes return 查無 rather than an empty string
- [x] d7eae4a: three different dates return three different figures matching the live API; non-trading days pass the upstream stat message through
- [x] 562a4d9: all four injected failures surface as 查詢失敗, with a genuine "no such company" case as the control
- [x] 4d85690: 37.85 MB → 3.8K chars; offset paging and out-
- [x] 4b283f0: block trades 40 → 39, credit limits 1300 → 1299, short sale/lending 1329 → 1328, quotes 3 → 2 支, and 9999 correctly returns 查無
- [x] uv run pytest — 176 passed (156 before; 20 new regresss against the pre-fix code)
- [x] server.py boots and registers all 180 tools