### PR TITLE
test: cover tools/other.py's hardcoded fields in the schema test

### DIFF
--- a/tests/tool_field_dependencies.py
+++ b/tests/tool_field_dependencies.py
@@ -48,6 +48,13 @@ TOOL_REQUIRED_FIELDS: Dict[str, List[str]] = {
     # --- statistics.py ---
     "/exchangeReport/MI_5MINS": ["AccAskOrders", "AccAskVolume", "AccBidOrders", "AccBidVolume", "AccTradeValue", "AccTradeVolume", "AccTransaction", "Time"],
 
+    # --- other.py ---
+    # get_fund_basic_info 讀基金名稱時有 基金中文名稱 → 基金名稱 → 基金簡稱 的備援鏈，
+    # 目前只有 基金名稱 存在；任一個在就不會顯示 N/A，故名稱欄位不列為必要欄位。
+    "/opendata/t187ap47_L": ["基金代號", "基金類型"],
+    "/exchangeReport/BFI61U": ["Code", "Name", "StartingDate"],
+    "/holidaySchedule/holidaySchedule": ["Date", "Description", "Name", "Weekday"],
+
     # --- broker.py ---
     "/opendata/t187ap01": ["合計", "受託買賣", "自行買賣", "職位"],
     "/opendata/t187ap19": ["出表日期", "公司總成交筆數", "成交月份", "成交筆數"],


### PR DESCRIPTION
## What changed

Three endpoints added to `tests/tool_field_dependencies.py`, plus one inline comment. No production code touched.

```python
# --- other.py ---
"/opendata/t187ap47_L": ["基金代號", "基金類型"],
"/exchangeReport/BFI61U": ["Code", "Name", "StartingDate"],
"/holidaySchedule/holidaySchedule": ["Date", "Description", "Name", "Weekday"],
```

`tests/test_api_schemas.py` is parametrized off that dict, so it picks the three up automatically — collection goes from 59 to 62 cases.

## Why

`tools/other.py` is the only tool module that hardcodes `.get("field")` against a TWSE OpenAPI response and has no entry in `tool_field_dependencies.py`, so the daily CI run never probes its endpoints:

- `tools/other.py:29-30` — `get_fund_basic_info` reads `基金代號` / `基金類型` from `/opendata/t187ap47_L`
- `tools/other.py:43` — `get_central_depository_bond_redemption` renders `/exchangeReport/BFI61U` via `create_simple_list_formatter("Name", "Code", "StartingDate")`, which `.get()`s those three names (`utils/formatters.py:186-196`)
- `tools/other.py:55-58` — `get_market_holiday_schedule` reads `Name` / `Date` / `Weekday` / `Description` from `/holidaySchedule/holidaySchedule`

If TWSE renames any of these, the three tools print `N/A` instead of real data and CI stays green — the exact silent breakage this test exists to catch (issue #58, and the `t187ap26_L`/`t187ap27_L` rename in #65, were both caught this way).

I checked the whole tree, not just this file: every other module that hardcodes fields against a TWSE OpenAPI endpoint is already covered — `market/indices.py` (`MI_INDEX`), `market/statistics.py` (`MI_5MINS`), `trading/periodic.py` (`FMSRFK_ALL`, `FMNPTK_ALL`), `trading/daily.py`, `trading/valuation.py`, `broker.py`, `company/basic_info.py`, `company/financials.py`, `company/esg.py`. `other.py` was the only gap.

The fund-name lookup is a `基金中文名稱 → 基金名稱 → 基金簡稱` fallback chain, so no single name field is required for the tool to render correctly. Listing one would make the test red on a rename the tool already absorbs, so it is left out and the reason is noted inline — the same style as the existing `CSR103` note at `tool_field_dependencies.py:75-76`.

## Convention followed

`CLAUDE.md` § "Adding New Tools" step 7: TWSE OpenAPI tools that hardcode field names get their endpoint added to `tests/tool_field_dependencies.py`; the parametrized test picks it up automatically. The file's own docstring states the same rule. Section comments are grouped per source module (`# --- market.py ---`, `# --- broker.py ---`, …); the new block follows that layout and the existing sorted-field ordering.

## Verified

- `uv sync --extra dev` clean.
- `uv run pytest tests/ --collect-only` — 187 tests collect; the three new parameters appear in `test_api_schemas.py`.
- `uv run pytest tests/test_helpers_unit.py` — passes (no network).
- Field names checked against `staticFiles/apis_summary_simple.json`, the repo's own API reference. As a confidence check on that file I diffed it against the **entire** existing `TOOL_REQUIRED_FIELDS`: all 59 endpoints are present and all of their required fields match, with no discrepancies — including the post-#65 `t187ap26_L`/`t187ap27_L` names.

## Could not verify

Egress to `openapi.twse.com.tw` is blocked in the environment I ran in, so **every** network test fails there — 59/59 `test_api_schemas.py` cases fail on the unmodified `main` with `ProxyError: Tunnel connection failed: 403 Forbidden`, and 62/62 with this change. The failures are environmental and identical in kind before and after; none of them are caused by this diff. The three new parameters were confirmed to collect, but not to pass against live data. CI has real network access and will be the first true check of them.

## Out of scope

- Non-TWSE-OpenAPI tools (TAIFEX, TPEx, MIS, legacy `exchangeReport`) keep their field assertions in `tests/e2e/test_*.py` per `CLAUDE.md`; they are already covered and untouched here.
- `tools/other.py` itself is unchanged — no behavior, docstring, or output string is modified.
- `CLAUDE.md`'s TPEx line still says "3 tools: 上櫃日收盤、三大法人、本益比" and its `tools/otc/` directory note still lists three modules, though PR #35 grew that to 10 tools across 9 modules (README.md:120 was updated, CLAUDE.md was not). Real drift, but unrelated to this diff — left for a separate docs PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E4ozwVDLqGZrMqGChD5ru5

---
_Generated by [Claude Code](https://claude.ai/code/session_01E4ozwVDLqGZrMqGChD5ru5)_