### PR TITLE
docs: resync CLAUDE.md's architecture map with the actual tree

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ TWStockMCPServer is a Model Context Protocol (MCP) server for Taiwan stock marke
 - **TWSE OpenAPI** (`openapi.twse.com.tw`) — 143 tools: 公司治理、ESG、財報、交易、指數、券商
 - **TWSE Web API** (`twse.com.tw`) — 16 tools: 歷史日K、月均價、融資融券（`/exchangeReport`）；估值（`/rwd/zh/afterTrading/BWIBBU_d` —— `/exchangeReport/BWIBBU_ALL` 會忽略 `date` 參數，只回最新交易日，不可用於歷史查詢）；三大法人買賣超日報、個股明細（`/rwd/zh/fund/T86`）；三大法人買賣金額、全市場收盤行情、市場成交量值、加權指數歷史、外資持股歷史（`/rwd/zh/...`，可查任意過去日期，與同名 openapi.twse.com.tw 端點僅回傳最近約12個交易日不同）；個股月/年成交彙總、鉅額交易明細（無伺服器端股票篩選，本地端過濾）、融券借券餘額/成交（`/rwd/zh/...`）（legacy JSON，非 Swagger）
 - **MIS 即時報價** (`mis.twse.com.tw`) — 1 tool: 盤中多股即時報價
-- **TPEx OpenAPI** (`tpex.org.tw/openapi`) — 3 tools: 上櫃日收盤、三大法人、本益比
+- **TPEx OpenAPI** (`tpex.org.tw/openapi`) — 10 tools: 上櫃日收盤、三大法人（個股/彙總）、本益比、融資融券、注意股、處置股、除權息、零股、櫃買指數
 - **TAIFEX OpenAPI** (`openapi.taifex.com.tw`) — 16 tools: 三大法人系列、大額交易人部位、每日行情、選擇權分析（Delta/OI增減）、保證金、年月統計
 - **TAIFEX 網站下載** (`www.taifex.com.tw`) — 9 tools: 期貨每日OHLC歷史、三大法人期貨部位歷史、Put/Call Ratio歷史、三大法人選擇權買賣權分計歷史、大額交易人未沖銷部位歷史（無伺服器端契約篩選，本地端過濾）、選擇權每日OHLC歷史、三大法人期貨+選擇權總表歷史、三大法人期貨/選擇權分計歷史、三大法人各選擇權契約歷史（HTML表單下載頁面，非 openapi.taifex.com.tw；後者無任何歷史查詢功能，僅回傳最新一個交易日）
 
@@ -33,11 +33,11 @@ TWStockMCPServer is a Model Context Protocol (MCP) server for Taiwan stock marke
 
 ```
 server.py                     # Thin entrypoint: FastMCP init, prompt registration, tool registration
-models/                       # Pydantic-style data models (MarketInfo, BrokerInfo, RealTimeStats)
 utils/
 ├── api_client.py             # TWSEAPIClient - all TWSE HTTP calls
 ├── config.py                 # APIConfig, DisplayConfig, TestConfig (env var overrides)
 ├── constants.py              # Localized message templates (Chinese)
+├── date_helper.py            # roc_to_ad() / ad_to_roc() for TWSE legacy ROC dates
 ├── decorators.py             # @handle_api_errors
 ├── formatters.py             # Data → string formatting functions
 ├── tool_factory.py           # create_company_tool() for dynamically named tools
@@ -56,7 +56,8 @@ tools/
                               #   short_sale_lending (rwd/* endpoints — accept arbitrary past dates, unlike the
                               #   openapi.twse.com.tw equivalents which only return a rolling ~12-day window)
 ├── realtime/                 # MIS real-time quotes: stock_info
-├── otc/                      # TPEx OTC market: daily_close, institutional, peratio
+├── otc/                      # TPEx OTC market: daily_close, institutional, institutional_summary, peratio,
+                              #   margin_balance, odd_lot, exright, index, trading_halt (注意股/處置股)
 └── taifex/                   # TAIFEX derivatives: futures_position, put_call_ratio, institutional_general,
                               #   institutional_details, daily_market_report, large_traders_oi,
                               #   options_analytics, margin, trading_statistics, futures_daily_history,


### PR DESCRIPTION
## What changed

Three corrections to `CLAUDE.md`, all in the "Project Overview" / "High-Level Structure" sections. Docs only — no code, no tool behaviour, no test changes.

1. Removed the `models/` entry from the file map (`CLAUDE.md:36`).
2. Added `utils/date_helper.py` to the `utils/` listing.
3. Updated the TPEx tool count `3 → 10` (`CLAUDE.md:11`) and expanded the `tools/otc/` module list (`CLAUDE.md:59`).

## Why

`CLAUDE.md` is the only architecture doc in this repo — it says so itself, and there is deliberately no `AGENTS.md` — so its file map is what a maintainer or agent reads before touching anything. Three entries no longer describe the code:

- **`models/` does not exist.** It was deleted in `78f8d97` ("refactor(phase-0): remove dead code and unify decorator signature"), and `grep -rn "models" --include=*.py .` returns nothing. `CLAUDE.md:36` still lists it as `# Pydantic-style data models (MarketInfo, BrokerInfo, RealTimeStats)`, which points a reader at a directory to put new models in that isn't there — and implies a Pydantic layer the project doesn't have.
- **`utils/date_helper.py` was missing from the map**, even though `CLAUDE.md:156` already instructs readers to "use `utils/date_helper.py` for conversion" when handling TWSE legacy ROC dates. The doc referenced a module its own structure section omitted.
- **`tools/otc/` grew from 3 to 10 modules** in `7c8dcfb` ("feat(otc): expand TPEx coverage from 3 to 10 tools"). `README.md:120` was updated in that commit; `CLAUDE.md` was not. So both the source-list count at `CLAUDE.md:11` ("3 tools") and the module list at `CLAUDE.md:59` ("daily_close, institutional, peratio") undercount by seven tools — `exright.py`, `index.py`, `institutional_summary.py`, `margin_balance.py`, `odd_lot.py`, and `trading_halt.py` (which registers two tools) are all invisible in the doc.

## Convention followed

The wording for the TPEx source line mirrors `README.md:120`, which the OTC expansion commit already updated (`櫃買中心 — 上櫃日收盤、三大法人（個股/彙總）、本益比、融資融券、注意/處置股、除權息、零股、指數 | 10 個`), so the two docs now agree. Keeping tool counts in `CLAUDE.md` current after adding tools is itself an established habit here — see `2c31ce6` ("docs: update TWSE Web API tool count (6 -> 11) for Tier 1 tools"). The multi-line comment continuation style used for the expanded `tools/otc/` entry copies the existing `tools/history/` and `tools/taifex/` entries in the same code block.

## Verified

- Counts checked against the code, not the docs: `uv run python -c "import asyncio, server; ..."` over `server.mcp.get_tools()` reports **10** `get_otc_*` tools (`get_otc_daily`, `get_otc_disposal_stocks`, `get_otc_exright`, `get_otc_index`, `get_otc_institutional`, `get_otc_institutional_summary`, `get_otc_margin_balance`, `get_otc_odd_lot`, `get_otc_valuation`, `get_otc_warning_stocks`), 180 tools in total.
- Also re-verified the entries I did **not** change and found them accurate, so they're left alone: TWSE Web API 16, TAIFEX OpenAPI 16, TAIFEX website-download 9, `prompts/` 9, and the `company/` `trading/` `market/` `history/` `taifex/` module lists.
- `uv sync --extra dev` and `uv run pytest tests/test_helpers_unit.py` — 7 passed. `import server` registers all tool modules cleanly.

## Could not verify

The live-API tests (`tests/test_api_schemas.py`, `tests/test_api_client_errors.py`, `tests/e2e/`) could not run in this sandbox: outbound requests to `openapi.twse.com.tw` are refused by the environment's network proxy (`ProxyError: Tunnel connection failed: 403 Forbidden`). That is an environment restriction, unrelated to this change — which touches no Python file at all.

## Out of scope (deliberately)

- The duplicated `YYYYMMDD` parse / span-check block across the nine `tools/taifex/*_history.py` modules, and the drift in its message (`futures_daily_history.py:87`, `options_daily_history.py:61` and `large_traders_futures_history.py:51` say `不可超過一個月` where the other six say `不可超過 {MAX_SPAN_DAYS} 天`). Consolidating it would change user-facing Chinese returned by three tools, which deserves its own PR.
- `README_en-us.md`, and the `TPEx` note under "External API Notes" (`CLAUDE.md:158`), which are both still accurate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011PhrZwuePjGZq6SKM11vvi

---
_Generated by [Claude Code](https://claude.ai/code/session_011PhrZwuePjGZq6SKM11vvi)_