### PR TITLE
fix: keep the request interval in force when a request fails

### DIFF
--- a/tests/test_api_client_errors.py
+++ b/tests/test_api_client_errors.py
@@ -6,6 +6,8 @@ None / []，導致 timeout、5xx、維護頁與「這家公司真的沒這筆資
 完全相同——@handle_api_errors 因此永遠不會觸發，MSG_QUERY_FAILED 形同死碼。
 """
 
+import time
+
 import pytest
 import requests
 
@@ -37,10 +39,14 @@ def _raise(exc):
     return _fake
 
 
-UPSTREAM_FAILURES = [
+# requests.request 本身就拋例外的故障（連 response 都拿不到）
+TRANSPORT_FAILURES = [
     pytest.param(_raise(requests.exceptions.Timeout("timed out")), id="timeout"),
     pytest.param(_raise(requests.exceptions.ConnectionError("refused")), id="connection-error"),
     pytest.param(_raise(requests.exceptions.HTTPError("503 Server Error")), id="http-503"),
+]
+
+UPSTREAM_FAILURES = TRANSPORT_FAILURES + [
     pytest.param(lambda *a, **kw: _MaintenancePage(), id="html-instead-of-json"),
 ]
 
@@ -76,6 +82,30 @@ def test_tool_reports_failure_not_missing_data(monkeypatch, client, fake_request
 
     result = mcp.tools["probe_tool"]("2330")
     assert result.startswith("查詢失敗"), f"故障被偽裝成正常回應: {result!r}"
+
+
+@pytest.mark.parametrize("fake_request", TRANSPORT_FAILURES)
+def test_rate_limit_still_applies_after_a_failure(monkeypatch, fake_request):
+    """故障也要計入節流：否則上游 429/5xx 時反而變成無間隔連打.
+
+    _request 曾經只在 raise_for_status() 之後才更新 _last_request_time，例外路徑
+    留下過期的時間戳，_throttle() 因此算出巨大的 elapsed 而完全跳過等待。
+    MI_MARGN 往前找 7 天、financials 逐一探測 6 個產業別端點這類重試迴圈，
+    會在上游最脆弱的時候變成毫無間隔的連續請求。
+    """
+    interval = 0.05
+    probe = TWSEAPIClient(request_interval=interval, cache_ttl=0)
+    monkeypatch.setattr(requests, "request", fake_request)
+
+    attempts = 4
+    start = time.monotonic()
+    for _ in range(attempts):
+        with pytest.raises(Exception):
+            probe.fetch_json("https://openapi.twse.com.tw/v1/probe")
+    elapsed = time.monotonic() - start
+
+    # attempts 次請求之間有 attempts-1 段間隔
+    assert elapsed >= interval * (attempts - 1), f"失敗後未節流，{attempts} 次僅耗時 {elapsed:.3f}s"
 
 
 def test_missing_company_still_reads_as_missing(client):

--- a/utils/api_client.py
+++ b/utils/api_client.py
@@ -58,17 +58,26 @@ class TWSEAPIClient:
         """Throttle, send GET/POST, stamp last-request time, and return the response."""
         self._throttle()
         logger.info(f"Fetching {method} {url} params={params}")
-        resp = requests.request(
-            method,
-            url,
-            params=params,
-            data=data,
-            headers=headers or {"User-Agent": self.user_agent, "Accept": "application/json"},
-            verify=self.verify_ssl,
-            timeout=timeout,
-        )
+        try:
+            resp = requests.request(
+                method,
+                url,
+                params=params,
+                data=data,
+                headers=headers or {"User-Agent": self.user_agent, "Accept": "application/json"},
+                verify=self.verify_ssl,
+                timeout=timeout,
+            )
+        finally:
+            # Stamp even when the call raises (timeout, connection error) or the
+            # response turns out to be an error status. A failed request still cost the
+            # upstream a hit, so leaving the stamp stale would make _throttle() see a
+            # huge elapsed time and skip the interval entirely — the retry loops that sit
+            # on top of this (MI_MARGN's 7-day walk-back, the industry-report probing in
+            # tools/company/financials.py) would then fire back-to-back with no spacing,
+            # exactly when TWSE is rate-limiting or down.
+            self._last_request_time = time.time()
         resp.raise_for_status()
-        self._last_request_time = time.time()
         resp.encoding = "utf-8"
         return resp
 


### PR DESCRIPTION
## What changed

`TWSEAPIClient._request` now stamps `_last_request_time` in a `finally` around the `requests.request` call, instead of after `resp.raise_for_status()`. Adds an offline unit test covering the three transport-failure cases.

## Why

`_request` stamped `_last_request_time` only once `raise_for_status()` had returned (`utils/api_client.py:70-71` on `main`). Any request that failed — timeout, connection error, 429, 5xx — left the stamp stale, so the next call's `_throttle()` (`utils/api_client.py:41-47`) computed a huge `elapsed` and skipped the wait entirely. The 0.5s rate limit that CLAUDE.md documents as built into the client silently vanished on exactly the requests that most need to back off.

Measured on an unmodified checkout — five consecutive `ConnectionError`s through `fetch_json` with `request_interval=0.5`:

```
5 failing requests took 0.000s (expected >= 2.0s with 0.5s throttle)
```

Two retry loops sit directly on top of this and turn it into a burst against an already-unhappy upstream:

- `tools/history/margin_balance.py:37` walks back up to 7 days, one `MI_MARGN` request per day
- `tools/company/financials.py:50` probes 6 industry-report endpoint variants per income-statement / balance-sheet lookup

Stamping in a `finally` covers both the raised cases and the error-status case, since `raise_for_status()` now runs after the stamp.

## Convention followed

- The fix stays inside `TWSEAPIClient`, the single injected client every tool module receives — no tool module changes, no new abstraction.
- The inline comment explains the measured reason for the placement, matching the existing comments in this file (`fetch_data`'s HTML-maintenance-page note, `fetch_company_data`'s "failures propagate deliberately").
- The test goes in `tests/test_api_client_errors.py`, the module that already monkeypatches `requests.request` to test client error paths offline, and uses its `_raise` helper and Chinese docstring style. `UPSTREAM_FAILURES` is split into `TRANSPORT_FAILURES` + the maintenance-page case so the new test only parametrizes over failures that never reach the stamp; the maintenance page returns 200 and was already stamped correctly. Existing parametrizations keep the same ids.

## Verified

- `uv sync --extra dev`, then `uv run pytest tests/ -k "not e2e"`: **22 offline tests pass**, including the 3 new ones.
- The new test fails on all three transport failures when `utils/api_client.py` is reverted, so it is not vacuous.

**Could not verify:** the 63 other failures in that run are tests that call live `openapi.twse.com.tw`, which this environment cannot reach (the proxy returns `403 Tunnel connection failed`). They fail identically on an unmodified checkout — this change does not affect them. The E2E suites were not run for the same reason.

## Out of scope

- No change to the interval value, no retry/backoff policy, no jitter — this only restores the interval the client already intends to enforce.
- The retry loops in `margin_balance.py` and `financials.py` are left as they are; they are correct once throttling actually applies to their failing requests.
- No change to `fetch_data`'s cache, to any tool output string, or to any external-API workaround documented in CLAUDE.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LFXPPhacvjkj3rG5HAnczz

---
_Generated by [Claude Code](https://claude.ai/code/session_01LFXPPhacvjkj3rG5HAnczz)_