### PR TITLE
fix: derive get_twse_news' month end from the AD year, not the ROC string

### DIFF
--- a/tests/test_news_date_range.py
+++ b/tests/test_news_date_range.py
@@ -1,0 +1,48 @@
+"""get_twse_news 只給 start_date 時的月底推算（不打網路）。
+
+只給 start_date 的分支要自行補出「該月最後一天」當作 end_date。原本的寫法是先把
+start_date 換成民國年字串，再從換好的字串反推西元年份（"1130201" → 1130+1911=3041），
+閏年判斷因此落在錯誤的年份上：查 2024-02 會以 28 日作結，2 月 29 日的新聞被靜默濾掉。
+"""
+
+import pytest
+
+from tests.helpers import register_module_tools
+from tools.company import news
+
+NEWS_ROWS = [
+    {"Date": "1130201", "Title": "二月第一天"},
+    {"Date": "1130228", "Title": "二月倒數第二天"},
+    {"Date": "1130229", "Title": "閏日"},
+    {"Date": "1130301", "Title": "三月第一天"},
+]
+
+
+class _StubClient:
+    """只回固定新聞清單的 client，取代 TWSEAPIClient 的 fetch_data."""
+
+    def fetch_data(self, endpoint, timeout=None):
+        return NEWS_ROWS
+
+
+@pytest.fixture
+def get_twse_news():
+    return register_module_tools(news, _StubClient())["get_twse_news"]
+
+
+def test_leap_day_is_included_when_only_start_date_given(get_twse_news):
+    """2024-02 是閏月，2 月 29 日必須留在區間內."""
+    result = get_twse_news(start_date="20240201")
+    assert "1130229" in result, f"閏日被濾掉了: {result!r}"
+
+
+def test_next_month_is_still_excluded(get_twse_news):
+    """月底推算不能寬鬆到把下個月的新聞也帶進來."""
+    result = get_twse_news(start_date="20240201")
+    assert "1130301" not in result, f"區間超出當月: {result!r}"
+
+
+def test_non_leap_february_ends_on_the_28th(get_twse_news):
+    """對照組：2025-02 不是閏月，1130229 這種日期不該出現在結果中."""
+    result = get_twse_news(start_date="20250201")
+    assert result == "", f"預期查無 2025-02 的新聞，實際: {result!r}"

--- a/tools/company/news.py
+++ b/tools/company/news.py
@@ -49,15 +49,17 @@ def register_tools(mcp: FastMCP, client: Optional[TWSEAPIClient] = None) -> None
         elif start_date and not end_date:
             # If only start_date provided, convert to 民國年 and use same month
             if len(start_date) == 8:  # YYYYMMDD format
-                year = int(start_date[:4]) - 1911
+                ad_year = int(start_date[:4])
+                year = ad_year - 1911
                 month = start_date[4:6]
                 day = start_date[6:8]
                 start_date = f"{year:03d}{month}{day}"
-                
-                # Set end_date to last day of that month
-                orig_year = int(start_date[:4]) + 1911 if len(start_date) == 7 else int(start_date[:3]) + 1911
-                orig_month = int(start_date[3:5]) if len(start_date) == 7 else int(start_date[3:5])
-                last_day = calendar.monthrange(orig_year, orig_month)[1]
+
+                # Set end_date to last day of that month. The leap-year rule has to be
+                # applied to the AD year: this used to re-read the already-converted
+                # 民國年 string, so "1130201" gave year 1130+1911=3041 and 2024-02 ended
+                # on the 28th, dropping every news item dated 1130229.
+                last_day = calendar.monthrange(ad_year, int(month))[1]
                 end_date = f"{year:03d}{month}{last_day:02d}"
         elif not start_date and end_date:
             # If only end_date provided, convert to 民國年 and use same month start


### PR DESCRIPTION
## What changed

`get_twse_news` (`tools/company/news.py`) now derives the "last day of the month" it fills into `end_date` from the AD year it was given, instead of re-parsing the string it had just converted to 民國年. Plus one offline regression test.

## Why

When the caller supplies only `start_date`, the tool auto-fills `end_date` with the last day of that month. Before this change, at `tools/company/news.py:55` `start_date` was reassigned to its ROC form, and the very next line read the first four characters of that 7-character string back as an AD year:

```python
start_date = f"{year:03d}{month}{day}"          # "20240201" -> "1130201"
orig_year = int(start_date[:4]) + 1911 if len(start_date) == 7 else ...   # 1130 + 1911 = 3041
last_day = calendar.monthrange(orig_year, orig_month)[1]
```

The wrong year only matters where the two disagree about leap days, i.e. February. Measured on an unmodified checkout:

| `start_date` | year used | `end_date` | correct |
|---|---|---|---|
| `20240201` | 3041 | `1130228` | `1130229` ❌ |
| `20200201` | 3001 | `1090228` | `1090229` ❌ |
| `20250201` | 3051 | `1140228` | ✅ (2025 not a leap year) |
| `20260601` | 3061 | `1150630` | ✅ (June is always 30) |

So a February-in-a-leap-year query silently loses the 29th: the string comparison at `news.py:89` (`start_date <= item_date <= end_date`) drops those rows, and the tool reports the truncated list as a normal result.

The fix keeps the AD year in a local before the conversion. That also removes the two `len(start_date) == 7` ternaries — the condition was always true at that point, and both branches of the second one (`orig_month`) were byte-for-byte identical, so the guard was dead either way.

## Conventions followed

- The tool's public signature, docstring, and returned Chinese strings are untouched — only the internal date arithmetic changes.
- The test registers the module through `tests.helpers.register_module_tools` with a stub client, the same offline pattern `tests/test_api_client_errors.py:79` uses via `_CapturingMCP`; test docstrings are in Chinese, matching `tests/test_helpers_unit.py`.
- No new dependency, abstraction, or tooling; `calendar.monthrange` was already imported and used in this function.
- CLAUDE.md's API-field test rule does not apply here — no hardcoded `.get("field")` access changed, so `tests/tool_field_dependencies.py` is untouched.

## Verified

- `uv sync --extra dev`, then `uv run pytest tests/ -k "not e2e"`: **25 offline tests pass**. The 65 failures in that run are all tests that call live `openapi.twse.com.tw`, which this environment cannot reach — the egress proxy answers `CONNECT` with `403 Forbidden`. They fail identically on an unmodified checkout (the count went 63 → 65 because #75 added two endpoints to the parametrized schema test).
- The new leap-day assertion fails on an unmodified checkout and passes with the fix; the other two (next month still excluded, non-leap February still ends on the 28th) pass either way and exist to pin the range's other edge.

## Not verified

- Live `/news/newsList` behaviour — the same proxy block prevents any request to TWSE from this environment. The test therefore stubs the response rows rather than asserting against real news data.

## Out of scope

- The other three date branches in `get_twse_news` (both dates given, only `end_date` given, neither given) compute correctly and are left alone.
- The function's overall shape — four near-parallel branches doing ROC conversion inline — is untouched; that would be a refactor, not this bug fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M2jKfgz58dPxD196AGPKC3

---
_Generated by [Claude Code](https://claude.ai/code/session_01M2jKfgz58dPxD196AGPKC3)_