### PR TITLE
refactor: 將 9 個 TAIFEX 歷史工具重複的起訖日期驗證收斂為單一 helper

### DIFF
--- a/tests/test_taifex_date_range_unit.py
+++ b/tests/test_taifex_date_range_unit.py
@@ -1,0 +1,55 @@
+"""parse_date_range 的單元測試（不打網路）。
+
+期交所網站下載頁面（www.taifex.com.tw）的 9 個歷史查詢工具共用這段起訖日期驗證，
+以往是各自複製一份。集中之後，這裡確保三種拒絕情形與邊界值不會在重構中被改掉。
+"""
+
+import pytest
+
+from tools.taifex.futures_daily_history import parse_date_range
+
+
+def test_valid_range_is_parsed():
+    start_dt, end_dt, error = parse_date_range("20260601", "20260630", 31, "20260601")
+    assert error is None
+    assert (start_dt.year, start_dt.month, start_dt.day) == (2026, 6, 1)
+    assert (end_dt.year, end_dt.month, end_dt.day) == (2026, 6, 30)
+
+
+def test_same_day_range_is_allowed():
+    _start_dt, _end_dt, error = parse_date_range("20260601", "20260601", 31, "20260601")
+    assert error is None
+
+
+@pytest.mark.parametrize("start_date,end_date", [
+    ("2026/06/01", "20260630"),
+    ("20260601", "2026-06-30"),
+    ("20261301", "20261330"),
+    ("", "20260630"),
+])
+def test_unparseable_dates_are_rejected(start_date, end_date):
+    start_dt, end_dt, error = parse_date_range(start_date, end_date, 31, "20260601")
+    assert (start_dt, end_dt) == (None, None)
+    assert "日期格式錯誤" in error
+
+
+def test_format_error_echoes_the_caller_s_example():
+    """例示日期由呼叫端傳入，需與該工具 docstring 的範例一致."""
+    _start_dt, _end_dt, error = parse_date_range("bad", "bad", 92, "20260401")
+    assert "20260401" in error
+
+
+def test_reversed_range_is_rejected():
+    start_dt, end_dt, error = parse_date_range("20260630", "20260601", 31, "20260601")
+    assert (start_dt, end_dt) == (None, None)
+    assert "不可晚於結束日期" in error
+
+
+def test_span_at_the_cap_is_allowed_but_one_day_over_is_not():
+    """上限為閉區間：剛好 31 天可查，32 天要擋下並回報實際天數."""
+    _start_dt, _end_dt, error = parse_date_range("20260601", "20260702", 31, "20260601")
+    assert error is None
+
+    start_dt, end_dt, error = parse_date_range("20260601", "20260703", 31, "20260601")
+    assert (start_dt, end_dt) == (None, None)
+    assert "31 天" in error and "收到 32 天" in error

--- a/tools/taifex/futures_daily_history.py
+++ b/tools/taifex/futures_daily_history.py
@@ -1,8 +1,9 @@
 """TAIFEX futures daily OHLC history (multi-day download, not exposed via openapi.taifex.com.tw).
 
-Also home to the shared helpers for parsing/decoding www.taifex.com.tw's HTML-form CSV
-download responses, reused by institutional_futures_history.py — the same pattern as
-TAIFEX_HEADERS living in futures_position.py and being imported by sibling modules.
+Also home to the shared helpers for validating the start/end date pair and for
+parsing/decoding www.taifex.com.tw's HTML-form CSV download responses, reused by every
+*_history.py module in this package — the same pattern as TAIFEX_HEADERS living in
+futures_position.py and being imported by sibling modules.
 """
 
 import csv
@@ -25,6 +26,44 @@ MAX_SPAN_DAYS = 31
 
 def parse_yyyymmdd(value: str) -> datetime:
     return datetime.strptime(value, "%Y%m%d")
+
+
+def parse_date_range(
+    start_date: str,
+    end_date: str,
+    max_span_days: int,
+    example: str,
+) -> Tuple[Optional[datetime], Optional[datetime], Optional[str]]:
+    """Parse and validate the YYYYMMDD start/end pair every download tool takes.
+
+    All of these tools reject a range on the same three grounds (unparseable date,
+    reversed order, span over the client-side cap), so the checks live here instead of
+    once per module. Returns (start_dt, end_dt, None) when the range is usable, or
+    (None, None, message) carrying the Chinese message the tool should return verbatim.
+
+    ``example`` is echoed in the format-error message so it matches the calling tool's
+    own docstring example.
+    """
+    try:
+        start_dt = parse_yyyymmdd(start_date)
+        end_dt = parse_yyyymmdd(end_date)
+    except ValueError:
+        return None, None, (
+            f"日期格式錯誤，請使用 YYYYMMDD 格式（例如 {example}），"
+            f"收到：start_date={start_date}, end_date={end_date}"
+        )
+
+    if start_dt > end_dt:
+        return None, None, f"起始日期 {start_date} 不可晚於結束日期 {end_date}"
+
+    span_days = (end_dt - start_dt).days
+    if span_days > max_span_days:
+        return None, None, (
+            f"查詢區間不可超過 {max_span_days} 天（收到 {span_days} 天），"
+            f"請縮小 start_date～end_date 範圍後重試"
+        )
+
+    return start_dt, end_dt, None
 
 
 def decode_and_parse_csv(body: bytes) -> Optional[Tuple[List[str], List[List[str]]]]:
@@ -75,16 +114,9 @@ def register_tools(mcp: FastMCP, client: Optional[TWSEAPIClient] = None) -> None
         Returns:
             區間內每個交易日、每個到期月份、一般與盤後時段的開高低收、成交量、未平倉資訊
         """
-        try:
-            start_dt = parse_yyyymmdd(start_date)
-            end_dt = parse_yyyymmdd(end_date)
-        except ValueError:
-            return f"日期格式錯誤，請使用 YYYYMMDD 格式（例如 20260601），收到：start_date={start_date}, end_date={end_date}"
-
-        if start_dt > end_dt:
-            return f"起始日期 {start_date} 不可晚於結束日期 {end_date}"
-        if (end_dt - start_dt).days > MAX_SPAN_DAYS:
-            return f"查詢區間不可超過一個月（收到 {(end_dt - start_dt).days} 天），請縮小 start_date～end_date 範圍後重試"
+        start_dt, end_dt, error = parse_date_range(start_date, end_date, MAX_SPAN_DAYS, "20260601")
+        if error:
+            return error
 
         contract = contract.strip().upper()
         body = _client.fetch_bytes(

--- a/tools/taifex/institutional_fut_opt_split_history.py
+++ b/tools/taifex/institutional_fut_opt_split_history.py
@@ -4,7 +4,7 @@ from typing import Optional
 from fastmcp import FastMCP
 from utils import TWSEAPIClient, handle_api_errors
 from .futures_position import TAIFEX_HEADERS
-from .futures_daily_history import parse_yyyymmdd, decode_and_parse_csv
+from .futures_daily_history import parse_date_range, decode_and_parse_csv
 
 # Distinct from get_institutional_total_history (futures+options combined into one
 # number) and get_institutional_traders_by_futures_history (futures only): this endpoint
@@ -38,16 +38,9 @@ def register_tools(mcp: FastMCP, client: Optional[TWSEAPIClient] = None) -> None
             區間內每個交易日、每個身份別（自營商/投信/外資及陸資）的期貨與選擇權各自多空
             交易口數、契約金額（千元）、未平倉口數
         """
-        try:
-            start_dt = parse_yyyymmdd(start_date)
-            end_dt = parse_yyyymmdd(end_date)
-        except ValueError:
-            return f"日期格式錯誤，請使用 YYYYMMDD 格式（例如 20260401），收到：start_date={start_date}, end_date={end_date}"
-
-        if start_dt > end_dt:
-            return f"起始日期 {start_date} 不可晚於結束日期 {end_date}"
-        if (end_dt - start_dt).days > MAX_SPAN_DAYS:
-            return f"查詢區間不可超過 {MAX_SPAN_DAYS} 天（收到 {(end_dt - start_dt).days} 天），請縮小 start_date～end_date 範圍後重試"
+        start_dt, end_dt, error = parse_date_range(start_date, end_date, MAX_SPAN_DAYS, "20260401")
+        if error:
+            return error
 
         body = _client.fetch_bytes(
             FUT_AND_OPT_DATE_DOWN_URL,

--- a/tools/taifex/institutional_futures_history.py
+++ b/tools/taifex/institutional_futures_history.py
@@ -9,7 +9,7 @@ from typing import Optional
 from fastmcp import FastMCP
 from utils import TWSEAPIClient, handle_api_errors, cap_rows
 from .futures_position import TAIFEX_HEADERS
-from .futures_daily_history import parse_yyyymmdd, decode_and_parse_csv
+from .futures_daily_history import parse_date_range, decode_and_parse_csv
 
 FUT_CONTRACTS_DATE_DOWN_URL = "https://www.taifex.com.tw/cht/3/futContractsDateDown"
 
@@ -44,16 +44,9 @@ def register_tools(mcp: FastMCP, client: Optional[TWSEAPIClient] = None) -> None
         Returns:
             區間內每個交易日、自營商/投信/外資及陸資的多空交易口數、契約金額、未平倉資訊
         """
-        try:
-            start_dt = parse_yyyymmdd(start_date)
-            end_dt = parse_yyyymmdd(end_date)
-        except ValueError:
-            return f"日期格式錯誤，請使用 YYYYMMDD 格式（例如 20260601），收到：start_date={start_date}, end_date={end_date}"
-
-        if start_dt > end_dt:
-            return f"起始日期 {start_date} 不可晚於結束日期 {end_date}"
-        if (end_dt - start_dt).days > MAX_SPAN_DAYS:
-            return f"查詢區間不可超過 {MAX_SPAN_DAYS} 天（收到 {(end_dt - start_dt).days} 天），請縮小 start_date～end_date 範圍後重試"
+        start_dt, end_dt, error = parse_date_range(start_date, end_date, MAX_SPAN_DAYS, "20260601")
+        if error:
+            return error
 
         contract = contract.strip().upper()
         body = _client.fetch_bytes(

--- a/tools/taifex/institutional_total_history.py
+++ b/tools/taifex/institutional_total_history.py
@@ -4,7 +4,7 @@ from typing import Optional
 from fastmcp import FastMCP
 from utils import TWSEAPIClient, handle_api_errors
 from .futures_position import TAIFEX_HEADERS
-from .futures_daily_history import parse_yyyymmdd, decode_and_parse_csv
+from .futures_daily_history import parse_date_range, decode_and_parse_csv
 
 # openapi.taifex.com.tw's get_institutional_general only returns the latest trading day.
 # This endpoint (www.taifex.com.tw download page) accepts an arbitrary date range. No
@@ -36,16 +36,9 @@ def register_tools(mcp: FastMCP, client: Optional[TWSEAPIClient] = None) -> None
             區間內每個交易日、每個身份別（自營商/投信/外資及陸資）的期貨+選擇權合計多空交易口數、
             契約金額（百萬元）、未平倉資訊
         """
-        try:
-            start_dt = parse_yyyymmdd(start_date)
-            end_dt = parse_yyyymmdd(end_date)
-        except ValueError:
-            return f"日期格式錯誤，請使用 YYYYMMDD 格式（例如 20260401），收到：start_date={start_date}, end_date={end_date}"
-
-        if start_dt > end_dt:
-            return f"起始日期 {start_date} 不可晚於結束日期 {end_date}"
-        if (end_dt - start_dt).days > MAX_SPAN_DAYS:
-            return f"查詢區間不可超過 {MAX_SPAN_DAYS} 天（收到 {(end_dt - start_dt).days} 天），請縮小 start_date～end_date 範圍後重試"
+        start_dt, end_dt, error = parse_date_range(start_date, end_date, MAX_SPAN_DAYS, "20260401")
+        if error:
+            return error
 
         body = _client.fetch_bytes(
             TOTAL_TABLE_DATE_DOWN_URL,

--- a/tools/taifex/large_traders_futures_history.py
+++ b/tools/taifex/large_traders_futures_history.py
@@ -4,7 +4,7 @@ from typing import Optional
 from fastmcp import FastMCP
 from utils import TWSEAPIClient, handle_api_errors
 from .futures_position import TAIFEX_HEADERS
-from .futures_daily_history import parse_yyyymmdd, decode_and_parse_csv
+from .futures_daily_history import parse_date_range, decode_and_parse_csv
 
 # openapi.taifex.com.tw's get_large_traders_futures_oi only returns the latest trading
 # day. This endpoint (www.taifex.com.tw download page) accepts an arbitrary date range,
@@ -39,16 +39,10 @@ def register_tools(mcp: FastMCP, client: Optional[TWSEAPIClient] = None) -> None
         Returns:
             區間內每個交易日，該契約各到期月份的前五大／前十大交易人買方、賣方部位數與全市場未沖銷部位數
         """
-        try:
-            start_dt = parse_yyyymmdd(start_date)
-            end_dt = parse_yyyymmdd(end_date)
-        except ValueError:
-            return f"日期格式錯誤，請使用 YYYYMMDD 格式（例如 20260601），收到：start_date={start_date}, end_date={end_date}"
+        start_dt, end_dt, error = parse_date_range(start_date, end_date, MAX_SPAN_DAYS, "20260601")
+        if error:
+            return error
 
-        if start_dt > end_dt:
-            return f"起始日期 {start_date} 不可晚於結束日期 {end_date}"
-        if (end_dt - start_dt).days > MAX_SPAN_DAYS:
-            return f"查詢區間不可超過一個月（收到 {(end_dt - start_dt).days} 天），請縮小 start_date～end_date 範圍後重試"
         if not contract or not contract.strip():
             return "contract 為必填參數，請指定期貨契約代碼（例如 TX、MTX、TE、TF）"
 

--- a/tools/taifex/options_daily_history.py
+++ b/tools/taifex/options_daily_history.py
@@ -4,7 +4,7 @@ from typing import Optional
 from fastmcp import FastMCP
 from utils import TWSEAPIClient, handle_api_errors, cap_rows
 from .futures_position import TAIFEX_HEADERS
-from .futures_daily_history import parse_yyyymmdd, decode_and_parse_csv
+from .futures_daily_history import parse_date_range, decode_and_parse_csv
 
 # openapi.taifex.com.tw's DailyMarketReportOpt (get_daily_options_market_report) only
 # returns the latest trading day. This endpoint (www.taifex.com.tw download page)
@@ -49,16 +49,9 @@ def register_tools(mcp: FastMCP, client: Optional[TWSEAPIClient] = None) -> None
         Returns:
             區間內每個交易日、指定到期月份各履約價的開高低收、成交量、結算價、未沖銷契約數
         """
-        try:
-            start_dt = parse_yyyymmdd(start_date)
-            end_dt = parse_yyyymmdd(end_date)
-        except ValueError:
-            return f"日期格式錯誤，請使用 YYYYMMDD 格式（例如 20260601），收到：start_date={start_date}, end_date={end_date}"
-
-        if start_dt > end_dt:
-            return f"起始日期 {start_date} 不可晚於結束日期 {end_date}"
-        if (end_dt - start_dt).days > MAX_SPAN_DAYS:
-            return f"查詢區間不可超過一個月（收到 {(end_dt - start_dt).days} 天），請縮小 start_date～end_date 範圍後重試"
+        start_dt, end_dt, error = parse_date_range(start_date, end_date, MAX_SPAN_DAYS, "20260601")
+        if error:
+            return error
 
         contract = contract.strip().upper()
         body = _client.fetch_bytes(

--- a/tools/taifex/options_institutional_by_contract_history.py
+++ b/tools/taifex/options_institutional_by_contract_history.py
@@ -4,7 +4,7 @@ from typing import Optional
 from fastmcp import FastMCP
 from utils import TWSEAPIClient, handle_api_errors
 from .futures_position import TAIFEX_HEADERS
-from .futures_daily_history import parse_yyyymmdd, decode_and_parse_csv
+from .futures_daily_history import parse_date_range, decode_and_parse_csv
 
 # Distinct from get_options_institutional_calls_puts_history: that tool splits CALL vs
 # PUT; this endpoint (optContractsDateDown) reports each contract's totals with CALL and
@@ -40,16 +40,9 @@ def register_tools(mcp: FastMCP, client: Optional[TWSEAPIClient] = None) -> None
             區間內每個交易日、每個身份別（自營商/投信/外資）在該契約的CALL+PUT合計多空交易口數、
             契約金額、未平倉資訊
         """
-        try:
-            start_dt = parse_yyyymmdd(start_date)
-            end_dt = parse_yyyymmdd(end_date)
-        except ValueError:
-            return f"日期格式錯誤，請使用 YYYYMMDD 格式（例如 20260401），收到：start_date={start_date}, end_date={end_date}"
-
-        if start_dt > end_dt:
-            return f"起始日期 {start_date} 不可晚於結束日期 {end_date}"
-        if (end_dt - start_dt).days > MAX_SPAN_DAYS:
-            return f"查詢區間不可超過 {MAX_SPAN_DAYS} 天（收到 {(end_dt - start_dt).days} 天），請縮小 start_date～end_date 範圍後重試"
+        start_dt, end_dt, error = parse_date_range(start_date, end_date, MAX_SPAN_DAYS, "20260401")
+        if error:
+            return error
 
         contract = contract.strip().upper()
         body = _client.fetch_bytes(

--- a/tools/taifex/options_institutional_history.py
+++ b/tools/taifex/options_institutional_history.py
@@ -4,7 +4,7 @@ from typing import Optional
 from fastmcp import FastMCP
 from utils import TWSEAPIClient, handle_api_errors
 from .futures_position import TAIFEX_HEADERS
-from .futures_daily_history import parse_yyyymmdd, decode_and_parse_csv
+from .futures_daily_history import parse_date_range, decode_and_parse_csv
 
 # openapi.taifex.com.tw's get_institutional_traders_calls_puts only returns the latest
 # trading day. This endpoint (www.taifex.com.tw download page) accepts an arbitrary date
@@ -35,16 +35,9 @@ def register_tools(mcp: FastMCP, client: Optional[TWSEAPIClient] = None) -> None
         Returns:
             區間內每個交易日、每個身份別（自營商/投信/外資）在 CALL/PUT 的買賣口數、契約金額、未平倉資訊
         """
-        try:
-            start_dt = parse_yyyymmdd(start_date)
-            end_dt = parse_yyyymmdd(end_date)
-        except ValueError:
-            return f"日期格式錯誤，請使用 YYYYMMDD 格式（例如 20260401），收到：start_date={start_date}, end_date={end_date}"
-
-        if start_dt > end_dt:
-            return f"起始日期 {start_date} 不可晚於結束日期 {end_date}"
-        if (end_dt - start_dt).days > MAX_SPAN_DAYS:
-            return f"查詢區間不可超過 {MAX_SPAN_DAYS} 天（收到 {(end_dt - start_dt).days} 天），請縮小 start_date～end_date 範圍後重試"
+        start_dt, end_dt, error = parse_date_range(start_date, end_date, MAX_SPAN_DAYS, "20260401")
+        if error:
+            return error
 
         contract = contract.strip().upper()
         body = _client.fetch_bytes(

--- a/tools/taifex/put_call_ratio_history.py
+++ b/tools/taifex/put_call_ratio_history.py
@@ -4,7 +4,7 @@ from typing import Optional
 from fastmcp import FastMCP
 from utils import TWSEAPIClient, handle_api_errors
 from .futures_position import TAIFEX_HEADERS
-from .futures_daily_history import parse_yyyymmdd, decode_and_parse_csv
+from .futures_daily_history import parse_date_range, decode_and_parse_csv
 
 # openapi.taifex.com.tw's PutCallRatio endpoint (get_put_call_ratio) already returns a
 # rolling ~21-trading-day window with no date param. This endpoint (www.taifex.com.tw's
@@ -33,16 +33,9 @@ def register_tools(mcp: FastMCP, client: Optional[TWSEAPIClient] = None) -> None
         Returns:
             區間內每個交易日的賣權/買權成交量、買賣權成交量比率%、賣權/買權未平倉量、買賣權未平倉量比率%
         """
-        try:
-            start_dt = parse_yyyymmdd(start_date)
-            end_dt = parse_yyyymmdd(end_date)
-        except ValueError:
-            return f"日期格式錯誤，請使用 YYYYMMDD 格式（例如 20260501），收到：start_date={start_date}, end_date={end_date}"
-
-        if start_dt > end_dt:
-            return f"起始日期 {start_date} 不可晚於結束日期 {end_date}"
-        if (end_dt - start_dt).days > MAX_SPAN_DAYS:
-            return f"查詢區間不可超過 {MAX_SPAN_DAYS} 天（收到 {(end_dt - start_dt).days} 天），請縮小 start_date～end_date 範圍後重試"
+        start_dt, end_dt, error = parse_date_range(start_date, end_date, MAX_SPAN_DAYS, "20260501")
+        if error:
+            return error
 
         body = _client.fetch_bytes(
             PC_RATIO_DOWN_URL,


### PR DESCRIPTION
## 改了什麼

把 `tools/taifex/` 底下 9 個「期交所網站下載頁面」歷史查詢工具各自複製一份的起訖日期驗證區塊，抽成 `tools/taifex/futures_daily_history.py` 的 `parse_date_range()`，各模組改為呼叫它。

每個呼叫端從 10 行縮成 3 行：

```python
start_dt, end_dt, error = parse_date_range(start_date, end_date, MAX_SPAN_DAYS, "20260601")
if error:
    return error
```

同時新增 `tests/test_taifex_date_range_unit.py`（不打網路），涵蓋三種拒絕情形與區間上限的邊界值。

## 為什麼

同一段 10 行驗證（日期無法解析、起訖顛倒、區間超過本地端上限）被完整複製 9 次，而且已經走鐘了 —— 其中 6 個模組回報的是實際天數，另外 3 個只寫「一個月」：

| 檔案 | `MAX_SPAN_DAYS` | 超過上限時的訊息 |
|------|----------------|------------------|
| `tools/taifex/futures_daily_history.py:87` | 31 | `查詢區間不可超過一個月` |
| `tools/taifex/options_daily_history.py:61` | 31 | `查詢區間不可超過一個月` |
| `tools/taifex/large_traders_futures_history.py:51` | 31 | `查詢區間不可超過一個月` |
| `tools/taifex/put_call_ratio_history.py:45` | 30 | `查詢區間不可超過 30 天` |
| `tools/taifex/institutional_futures_history.py:56` | 92 | `查詢區間不可超過 92 天` |
| `tools/taifex/institutional_total_history.py:48` | 92 | `查詢區間不可超過 92 天` |
| `tools/taifex/institutional_fut_opt_split_history.py:50` | 92 | `查詢區間不可超過 92 天` |
| `tools/taifex/options_institutional_history.py:47` | 92 | `查詢區間不可超過 92 天` |
| `tools/taifex/options_institutional_by_contract_history.py:52` | 92 | `查詢區間不可超過 92 天` |

「一個月」對呼叫端（MCP client / LLM）沒有可操作性：收到這句話無法判斷該把區間縮到幾天才會過。收斂之後這 3 個工具會回報程式碼實際執行的 31 天上限，與其餘 6 個一致。

實務上的維護成本：日後任何一項調整（例如要擋未來日期、要容忍 `2026/06/01` 這種格式、要改寫訊息）都得改 9 個地方，而這次的走鐘正說明了漏改是會發生的。

## 遵循的既有慣例

- **共用 helper 放在 sibling 模組、由同 package 匯入**：`tools/taifex/futures_daily_history.py:1-6` 的 module docstring 本來就寫明它是這組下載頁面工具的共用 helper 之家（`parse_yyyymmdd`、`decode_and_parse_csv`），並註明「the same pattern as TAIFEX_HEADERS living in `futures_position.py` and being imported by sibling modules」。新的 `parse_date_range()` 就放在同一處，沒有新增模組、新增抽象層或新的設計模式。
- **helper 以 `Optional` / tuple 回傳而非丟例外**：與同檔的 `decode_and_parse_csv()` 回傳 `Optional[Tuple[...]]` 一致。
- **錯誤訊息維持中文、由工具原樣回傳**：與 `utils/constants.py`、各工具現有的在地化訊息一致。
- **離線單元測試**：`tests/test_taifex_date_range_unit.py` 比照 `tests/test_helpers_unit.py`（中文 docstring 說明「判錯的代價」、`pytest.mark.parametrize`、不打網路）。
- CLAUDE.md 的「API field tests」規則不適用：本次沒有新增或變更任何 `.get("欄位")` 硬編欄位存取，故 `tests/tool_field_dependencies.py` 無需更動。

## 驗證了什麼

- `uv sync --extra dev` ✅
- `uv run pytest tests/test_taifex_date_range_unit.py tests/test_helpers_unit.py tests/test_news_date_range.py` → **19 passed** ✅
- 載入 `server.py` 確認 180 個 tool 全部註冊成功，並實際呼叫 5 個受影響工具的驗證路徑（皆在發出 HTTP request 前就回傳），輸出與改動前逐字相同，唯一差異是前述 3 個工具的「一個月」→「31 天」：
  ```
  get_futures_daily_history          → 日期格式錯誤，請使用 YYYYMMDD 格式（例如 20260601），收到：start_date=2026/06/01, end_date=20260630
  get_options_daily_history          → 起始日期 20260630 不可晚於結束日期 20260601
  get_large_traders_futures_history  → 查詢區間不可超過 31 天（收到 61 天），請縮小 start_date～end_date 範圍後重試
  get_large_traders_futures_history  → contract 為必填參數，請指定期貨契約代碼（例如 TX、MTX、TE、TF）
  get_put_call_ratio_history         → 查詢區間不可超過 30 天（收到 61 天），請縮小 start_date～end_date 範圍後重試
  get_institutional_total_history    → 查詢區間不可超過 92 天（收到 153 天），請縮小 start_date～end_date 範圍後重試
  ```
  （`get_large_traders_futures_history` 的 `contract` 必填檢查仍排在區間檢查之後，順序未變。）

**無法驗證的部分**：`uv run pytest tests/ -x -k "not e2e"` 在本次執行環境跑不完 —— `tests/test_api_client_errors.py` 雖然不在 `tests/e2e/` 底下，但會呼叫線上 TWSE API，在此沙箱被 proxy 擋掉（`ProxyError: Tunnel connection failed: 403 Forbidden`）。這與本次改動無關，該檔案完全沒有被本 PR 觸及。所有需要連外的 E2E 測試（`tests/e2e/test_taifex_history_api.py` 等）同樣無法在此環境執行，需由 CI 驗證。

## 刻意不做的事

- **不動 9 個工具的 docstring**：docstring 就是 MCP tool description，屬對外契約。其中 3 個仍寫「區間不可超過一個月」——對 31 天的上限而言是正確的口語描述，不需要為了跟錯誤訊息用字一致而改動對外描述。
- **不調整任何 `MAX_SPAN_DAYS` 數值**：每個常數上方都有實測依據的註解（伺服器端硬性上限 vs. 為了控制輸出量的本地端上限），不在本次範圍。
- **不放進 `utils/date_helper.py`**：該模組是 TWSE 民國年轉換用的通用工具，而 `parse_date_range()` 的錯誤訊息綁定 TAIFEX 這組工具的參數名（`start_date`／`end_date`），留在 `tools/taifex/` 較貼合現有分層。
- **不順手改動 `parse_yyyymmdd`、`decode_and_parse_csv` 或任何 CLAUDE.md 記載的外部 API workaround。**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jw11XNmnMj74qNX9oF8wxi

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jw11XNmnMj74qNX9oF8wxi)_