### PR TITLE
fix: 清單工具在關鍵字過濾後查無資料時不再回傳空字串

### DIFF
--- a/tests/test_list_response_unit.py
+++ b/tests/test_list_response_unit.py
@@ -1,0 +1,70 @@
+"""format_list_response 在「一筆都不剩」時的回覆（不打網路）。
+
+清單工具幾乎都是先抓整份資料、再用 name 關鍵字或有效欄位條件過濾，最後交給
+format_list_response 排版。過濾到一筆不剩是日常情況（關鍵字打錯、當天沒有符合的個股），
+此時若回空字串，MCP 呼叫端看到的就是完全空白的工具回覆，跟工具壞掉無法區分。
+"""
+
+import pytest
+
+from tests.helpers import register_module_tools
+from utils.constants import MSG_NO_MATCHING_DATA
+from utils.formatters import format_list_response
+import tools.company.listing as listing
+import tools.trading.market as market
+
+
+class _StubClient:
+    """只回固定資料的假 client，讓工具能離線跑完整條路徑."""
+
+    def __init__(self, rows):
+        self._rows = rows
+
+    def fetch_data(self, endpoint, timeout=None):
+        return list(self._rows)
+
+
+def test_empty_list_says_why_instead_of_returning_blank():
+    result = format_list_response([], "最近上市公司資料")
+    assert result == MSG_NO_MATCHING_DATA.format(data_type="最近上市公司資料")
+
+
+def test_non_empty_list_is_unchanged():
+    result = format_list_response([{"Code": "2330"}], "測試資料")
+    assert "共有 1 筆測試資料" in result
+    assert "Code: 2330" in result
+
+
+def test_name_filter_with_no_match_is_explicit():
+    """create_list_tool 的 name 關鍵字過濾掉全部資料時要有訊息（涵蓋 27 支清單工具）."""
+    client = _StubClient([{"Code": "2330", "Company": "台積電", "ListingDate": "1123456"}])
+    tools = register_module_tools(listing, client)
+
+    result = tools["get_recently_listed_companies"](name="不存在的公司")
+
+    assert result.strip(), "過濾後無資料時回了空字串"
+    assert "查無" in result, f"未說明查無符合條件的資料: {result!r}"
+
+
+def test_direct_call_site_name_filter_with_no_match_is_explicit():
+    """直接呼叫 format_list_response 的工具同樣不該回空字串."""
+    client = _StubClient([
+        {"Code": "2330", "Name": "台積電", "Number": "1", "NumberOfAnnouncement": "1",
+         "TradingInfoForAttention": "-", "Date": "1123456", "ClosingPrice": "1000", "PE": "20"},
+    ])
+    tools = register_module_tools(market, client)
+
+    result = tools["get_today_notice_stocks"](name="不存在的公司")
+
+    assert result.strip(), "過濾後無資料時回了空字串"
+    assert "查無" in result, f"未說明查無符合條件的資料: {result!r}"
+
+
+@pytest.mark.parametrize("rows", [[], [{"Code": "", "Name": ""}]])
+def test_source_with_no_usable_rows_still_reports_no_data(rows):
+    """來源整份沒資料時仍走既有的 MSG_NO_DATA 路徑，不受本次修改影響."""
+    tools = register_module_tools(market, _StubClient(rows))
+
+    result = tools["get_today_notice_stocks"]()
+
+    assert "目前沒有集中市場當日公布注意股票資料。" == result

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -8,6 +8,7 @@ from .constants import (
     MSG_NO_DATA,
     MSG_QUERY_FAILED,
     MSG_NO_DATA_FOR_CODE,
+    MSG_NO_MATCHING_DATA,
     MSG_TOTAL_RECORDS,
     SUMMARY_ROW_LABELS,
 )
@@ -38,6 +39,7 @@ __all__ = [
     "MSG_NO_DATA",
     "MSG_QUERY_FAILED",
     "MSG_NO_DATA_FOR_CODE",
+    "MSG_NO_MATCHING_DATA",
     "MSG_TOTAL_RECORDS",
     "SUMMARY_ROW_LABELS",
     "handle_api_errors",

--- a/utils/constants.py
+++ b/utils/constants.py
@@ -9,6 +9,9 @@ DEFAULT_DISPLAY_LIMIT = DisplayConfig.DEFAULT_DISPLAY_LIMIT
 MSG_NO_DATA = "目前沒有{data_type}資料。"
 MSG_QUERY_FAILED = "查詢失敗: {error}"
 MSG_NO_DATA_FOR_CODE = "查無{query_target}的{data_type}"
+# 清單經過篩選（name 關鍵字、有效欄位檢查）後一筆不剩時使用。與 MSG_NO_DATA 分開：
+# 那句是「來源整份沒有資料」，這句是「來源有資料，但沒有符合這次查詢條件的」。
+MSG_NO_MATCHING_DATA = "查無符合條件的{data_type}。"
 
 # Success messages
 MSG_TOTAL_RECORDS = "共有 {count} 筆{data_type}："

--- a/utils/formatters.py
+++ b/utils/formatters.py
@@ -1,7 +1,7 @@
 """Data formatting utilities."""
 
 from typing import Any, List, Union, Sequence
-from .constants import MSG_TOTAL_RECORDS, DEFAULT_DISPLAY_LIMIT
+from .constants import MSG_TOTAL_RECORDS, MSG_NO_MATCHING_DATA, DEFAULT_DISPLAY_LIMIT
 from .types import TWSEDataItem, DataFormatter
 
 def format_properties_with_values_multiline(data: TWSEDataItem) -> str:
@@ -130,10 +130,14 @@ def format_list_response(
         offset: Number of records to skip from the start (default 0)
 
     Returns:
-        Formatted string with header, items, and pagination info
+        Formatted string with header, items, and pagination info, or MSG_NO_MATCHING_DATA
+        when there is nothing to show
     """
     if not data:
-        return ""
+        # 呼叫端多半在抓完資料後才做 name 關鍵字或有效欄位過濾，過濾到一筆不剩時就會走到
+        # 這裡。回空字串等於讓工具回覆一片空白，呼叫端無從分辨是「查無符合的資料」還是
+        # 工具壞掉，所以這裡必須自己講清楚。
+        return MSG_NO_MATCHING_DATA.format(data_type=data_type)
 
     total = len(data)
     page_data = data[offset:offset + limit]


### PR DESCRIPTION
## 改了什麼

`format_list_response` 在收到空清單時原本 `return ""`（`utils/formatters.py:135`），改成回傳新增的 `MSG_NO_MATCHING_DATA`（`查無符合條件的{data_type}。`）。

## 為什麼

清單工具的流程都是「抓整份資料 → `if not data` 擋掉來源沒資料 → 再用 name 關鍵字或有效欄位條件過濾 → 交給 `format_list_response` 排版」。**過濾後一筆不剩會落在同一條空清單路徑，工具因此回覆一片空白**，呼叫端無法分辨是「查無符合條件的資料」還是工具壞掉。這不是邊界情況：關鍵字打錯、或某公司當天本來就不在處置股／注意股名單上，就會踩到。

受影響的是 33 支工具：

- 由 `create_list_tool` 產生、且有 name 關鍵字的 27 支（`utils/tool_factory.py:94-96` 先過濾再呼叫 `format_list_response`，來源為 `tools/trading/market.py:143`、`tools/company/basic_info.py:151`、`tools/broker.py:81`、`tools/company/listing.py:55`）
- 自行過濾後直接呼叫的 6 支，例如 `tools/trading/market.py:334-352`（`get_today_notice_stocks`）、`tools/company/basic_info.py:177-190`（`get_company_board_insufficient_shares`），以及 `basic_info.py:322 / 379 / 413`、`market.py:313`

實例：`get_recently_listed_companies(name="不存在的公司")` 修改前回傳 `""`，修改後回傳 `查無符合條件的最近上市公司資料。`

## 遵循了哪些既有慣例

- CLAUDE.md「Adding New Tools」第 4 點：*check for empty/None results explicitly and return* 明確訊息，不要回空值。
- 訊息集中放在 `utils/constants.py`，與 `MSG_NO_DATA` / `MSG_NO_DATA_FOR_CODE` 並列。之所以另開一個常數而不共用 `MSG_NO_DATA`，是因為兩句話的語意不同：`MSG_NO_DATA` 是「來源整份沒有資料」，本次新增的是「來源有資料，但沒有符合這次查詢條件的」；且多數 `data_type` 標籤本身以「資料」結尾，套用 `MSG_NO_DATA` 會變成「…資料資料。」。
- 沒有走共用 helper 的歷史／櫃買工具早就是這樣做的，只是各自寫在模組裡，例如 `tools/history/block_trades_detail.py:52-55` 的「查無名稱包含「{name}」的股票…」。本次只是讓共用排版函式也把話講清楚。
- 離線單元測試比照 `tests/test_taifex_date_range_unit.py`、`tests/test_helpers_unit.py` 的寫法，並沿用 `tests/helpers.py` 的 `register_module_tools` 搭配假 client，不打網路。

## 驗證了什麼

- `uv sync --extra dev` 正常。
- 新增的 `tests/test_list_response_unit.py` 6 項全過；把 `utils/formatters.py` 的修改暫時 stash 後，其中 3 項如預期失敗（確認測到的就是這個 bug）。
- 一併跑過其餘不需網路的測試檔（`test_helpers_unit.py`、`test_taifex_date_range_unit.py`、`test_news_date_range.py`、`test_api_client_errors.py`）：40 passed。
- **無法驗證的部分**：本次執行環境的對外連線被 proxy 擋掉（`openapi.twse.com.tw`、`www.twse.com.tw` 皆為 403），所以 `tests/e2e/` 與 `tests/test_api_schemas.py` 完全跑不了；`tests/test_api_client_errors.py::test_missing_company_still_reads_as_missing` 也因此失敗，與本次修改無關（該測試會實際呼叫 TWSE OpenAPI）。這次沒有異動任何欄位存取，故不需更新 `tests/tool_field_dependencies.py`。

## 刻意不做的事

- 有資料時的輸出完全沒動，逐字元相同；有先擋掉「來源沒資料」的呼叫端也維持原本的 `MSG_NO_DATA` 訊息。
- `offset` 超出範圍時表頭會印出「顯示第 101–50 筆」這類錯亂區間的問題，只有 `tools/history/margin_balance.py`、`tools/history/bwibbu_all.py` 有處理（並有 `tests/e2e/test_output_limits.py` 的「超出範圍」斷言把關），其餘沿用同一段分頁樣板的模組都沒有。那是另一個問題，留給獨立 PR，不併進來。
- 其他也會回空字串的路徑（例如 `format_multiple_records(data) if data else ""`、`get_warrant_basic_info` 指定 code 查無結果）不在本次範圍內。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014yKS2t9qFppxj9gDT46x55

---
_Generated by [Claude Code](https://claude.ai/code/session_014yKS2t9qFppxj9gDT46x55)_