### PR TITLE
fix: get_stock_yearly_history 改用當天日期查 FMNPTK，不再寫死 20260101

### DIFF
--- a/tests/test_yearly_history_date_unit.py
+++ b/tests/test_yearly_history_date_unit.py
@@ -1,0 +1,58 @@
+"""get_stock_yearly_history 送出的查詢日期不會凍結在某個年份（不打網路）。
+
+FMNPTK 以 date 的年份當作歷年序列的終點。日期若寫死成某一年，跨年之後最新年度就會從
+結果中默默消失：輸出格式一切正常，只是少了一列，呼叫端沒有任何線索可以察覺。
+"""
+
+from datetime import datetime
+
+import pytest
+
+from tests.helpers import register_module_tools
+from tools.history import stock_monthly_yearly_history
+
+# FMNPTK tables[0] 的 row 結構：年度,成交股數,成交金額,成交筆數,最高價,日期,最低價,日期,收盤平均價
+YEARLY_ROWS = [
+    ["113", "1,000", "2,000", "30", "600.00", "113/01/02", "500.00", "113/03/04", "550.00"],
+    ["114", "1,100", "2,200", "33", "700.00", "114/01/02", "600.00", "114/03/04", "650.00"],
+]
+
+
+class _CapturingClient:
+    """記下最後一次 fetch_json 的 params，並回一份 FMNPTK 形狀的固定資料."""
+
+    def __init__(self):
+        self.last_params = None
+
+    def fetch_json(self, url, params=None, timeout=None, headers=None):
+        self.last_params = params
+        return {"stat": "OK", "tables": [{"data": YEARLY_ROWS}]}
+
+
+@pytest.fixture
+def client():
+    return _CapturingClient()
+
+
+@pytest.fixture
+def get_stock_yearly_history(client):
+    tools = register_module_tools(stock_monthly_yearly_history, client)
+    return tools["get_stock_yearly_history"]
+
+
+def test_query_date_is_today(get_stock_yearly_history, client):
+    get_stock_yearly_history("2330")
+    assert client.last_params["date"] == datetime.now().strftime("%Y%m%d")
+
+
+def test_query_date_tracks_the_current_year(get_stock_yearly_history, client):
+    """真正會壞掉的是年份：年份寫死時，跨年後最新一年不會出現在結果裡."""
+    get_stock_yearly_history("2330")
+    assert client.last_params["date"][:4] == str(datetime.now().year)
+
+
+def test_rows_are_still_rendered(get_stock_yearly_history):
+    """對照組：確認上面兩項不是因為工具整個查詢失敗才通過."""
+    result = get_stock_yearly_history("2330")
+    assert "共 2 年" in result
+    assert "114年" in result

--- a/tools/history/stock_monthly_yearly_history.py
+++ b/tools/history/stock_monthly_yearly_history.py
@@ -1,5 +1,6 @@
 """TWSE per-stock monthly/yearly aggregated trading history."""
 
+from datetime import datetime
 from typing import Optional
 from fastmcp import FastMCP
 from utils import TWSEAPIClient, handle_api_errors
@@ -63,9 +64,13 @@ def register_tools(mcp: FastMCP, client: Optional[TWSEAPIClient] = None) -> None
         Returns:
             每年度的最高價（及日期）、最低價（及日期）、收盤平均價、成交股數、成交金額、成交筆數
         """
+        # FMNPTK 以 date 的年份當作歷年序列的終點。這裡原本寫死 "20260101"，等於把終點
+        # 凍結在當初寫程式的年份：跨年之後最新年度會從結果中默默消失（輸出格式完全正常，
+        # 只是少一列）。此工具不收日期參數——查的就是「到今天為止的歷年」——所以每次呼叫
+        # 都以當天日期查詢。
         resp = _client.fetch_json(
             FMNPTK_URL,
-            params={"response": "json", "date": "20260101", "stockNo": stock_no},
+            params={"response": "json", "date": datetime.now().strftime("%Y%m%d"), "stockNo": stock_no},
         )
 
         if not resp or resp.get("stat") != "OK":


### PR DESCRIPTION
## 改了什麼

`get_stock_yearly_history` 送給 FMNPTK 的 `date` 參數，從寫死的字串 `"20260101"` 改成每次呼叫時計算的當天日期（`tools/history/stock_monthly_yearly_history.py:68`）。工具的簽章、輸出格式、訊息文字都沒有動。

## 為什麼

FMNPTK（個股歷年成交資訊）以 `date` 的**年份**作為歷年序列的終點，寫死日期等於把終點凍結在當初寫程式的那一年。這段是 2026-07-18 的 `7575763`（feat: add TWSE Tier 2 historical-data tools）加進來的，當時的「今年」剛好就是 2026，所以到目前為止還看不出問題；**2027-01-01 起，最新年度就會從結果中默默消失，而且每過一年就少一年**。

這種壞法特別難察覺：輸出格式完全正常（`【2330 歷年成交資訊】（共 N 年）` 加上逐年明細），只是少了最新的一列，呼叫端沒有任何線索可以判斷資料被截斷。

證據與依據：

- `tools/history/stock_monthly_yearly_history.py:68` —— 全 repo 唯一一處寫死的查詢日期。`grep -rn "2026" tools/` 的其他命中都是 `parse_date_range(...)` 的格式錯誤訊息範例（例如 `tools/taifex/futures_daily_history.py:117`），只會出現在錯誤訊息裡，不影響查詢結果。
- 同一個檔案裡的姊妹工具 `get_stock_monthly_history` 的 docstring（`tools/history/stock_monthly_yearly_history.py:22-23`）已經寫明這族端點的行為：「只有 date 的年份會影響查詢結果：查當年會回傳至今每月資料，查過去年份則回傳該年全部12個月」。
- `get_stock_yearly_history` 本身不收日期參數，語意就是「到目前為止的歷年」，所以正確的日期只有「今天」。

## 遵循了哪些既有慣例

- `tools/history/` 底下其他 legacy TWSE 工具（`stock_day.py`、`bwibbu_all.py`、`all_stocks_daily_close.py`、`block_trades_detail.py` 等）的查詢日期一律來自呼叫端參數，沒有任何一支把日期寫死。
- 取「現在」的寫法沿用 `tools/company/news.py:41` 的 `datetime.now()`。
- 離線單元測試比照 `tests/test_news_date_range.py`（PR #76）與 `tests/test_taifex_date_range_unit.py`（PR #77）：用 `tests/helpers.py` 的 `register_module_tools` 搭配假 client，不打網路。這裡的假 client 額外記下最後一次 `fetch_json` 的 `params`，用來斷言送出的日期。
- 註解語言沿用該檔案既有的中文敘述。

## 驗證了什麼

- `uv sync --extra dev` 正常。
- 新增的 `tests/test_yearly_history_date_unit.py` 3 項全過。把 `tools/history/` 的修改暫時 stash 後，`test_query_date_is_today` 如預期失敗——`test_query_date_tracks_the_current_year` 在今天（2026 年）**還會通過**，正好說明這個 bug 現在只差在日期、跨年後才會差在年份。
- 一併跑過其餘不需網路的測試檔（`test_news_date_range.py`、`test_taifex_date_range_unit.py`、`test_helpers_unit.py`、`test_api_client_errors.py`）：37 passed。
- **無法驗證的部分**：本次執行環境的對外連線被 egress proxy 擋掉（`openapi.twse.com.tw`、`www.twse.com.tw`、`www.tpex.org.tw` 一律 `403 Tunnel connection failed`），所以 `uv run pytest tests/ -k "not e2e"` 的 65 個失敗全部來自 `tests/test_api_schemas.py` 與 `tests/test_api_client_errors.py::test_missing_company_still_reads_as_missing` 的實際 API 呼叫，與本次修改無關（本次只動了一個 module 的一個查詢參數）；`tests/e2e/` 同理完全跑不了。**因此「FMNPTK 以 date 年份截斷序列」這點是依據姊妹端點的已記錄行為與這段程式碼的寫法推得，沒有當場對線上 API 實測。** 即使該端點其實完全忽略 `date`，這次改動也只會是 no-op，不會讓結果變少。
- 沒有新增或改動任何 `.get("欄位")` 存取，故不需更新 `tests/tool_field_dependencies.py`（該工具走的是 row 位置索引，欄位數已由 `tests/e2e/test_history_tier2_api.py::TestStockYearlyHistoryAPI` 把關）。

## 刻意不做的事

- 沒有替 `get_stock_yearly_history` 加上 `date` 參數。它的定位就是「查到今天為止的歷年」，加參數會動到公開的 MCP 工具簽章。
- 沒有碰同檔案的 `get_stock_monthly_history`：它的日期本來就由呼叫端提供，行為正確。
- 沒有一併處理其他模組的分頁／`offset` 越界問題，那與本次修改無關。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JDUsoQ3qj4usaEZVvuhrFV

---
_Generated by [Claude Code](https://claude.ai/code/session_01JDUsoQ3qj4usaEZVvuhrFV)_