### PR TITLE
fix: offset 翻過資料尾端時明說「已超出範圍」，不再回一個空白分頁

### DIFF
--- a/tests/test_list_response_unit.py
+++ b/tests/test_list_response_unit.py
@@ -8,7 +8,7 @@ format_list_response 排版。過濾到一筆不剩是日常情況（關鍵字�
 import pytest
 
 from tests.helpers import register_module_tools
-from utils.constants import MSG_NO_MATCHING_DATA
+from utils.constants import MSG_NO_MATCHING_DATA, MSG_OFFSET_OUT_OF_RANGE
 from utils.formatters import format_list_response
 import tools.company.listing as listing
 import tools.trading.market as market
@@ -58,6 +58,46 @@ def test_direct_call_site_name_filter_with_no_match_is_explicit():
 
     assert result.strip(), "過濾後無資料時回了空字串"
     assert "查無" in result, f"未說明查無符合條件的資料: {result!r}"
+
+
+@pytest.mark.parametrize("offset", [2, 3, 100])
+def test_offset_past_the_last_record_is_explicit(offset):
+    """offset 翻過尾端時要講清楚，不能只回一個空頁的表頭."""
+    rows = [{"Code": "2330"}, {"Code": "2317"}]
+
+    result = format_list_response(rows, "測試資料", limit=50, offset=offset)
+
+    assert result == MSG_OFFSET_OUT_OF_RANGE.format(
+        offset=offset, data_type="測試資料", count=2
+    )
+
+
+def test_offset_past_the_last_record_does_not_print_an_impossible_range():
+    """回歸點：原本會輸出「共有 2 筆測試資料：（顯示第 101–2 筆）」後面接零列資料."""
+    result = format_list_response([{"Code": "2330"}, {"Code": "2317"}], "測試資料", offset=100)
+
+    assert "顯示第 101" not in result
+
+
+def test_last_page_within_range_is_unchanged():
+    """對照組：offset 還在範圍內時，分頁輸出不受影響."""
+    rows = [{"Code": "2330"}, {"Code": "2317"}]
+
+    result = format_list_response(rows, "測試資料", limit=1, offset=1)
+
+    assert "共有 2 筆測試資料" in result
+    assert "Code: 2317" in result
+    assert "超出範圍" not in result
+
+
+def test_tool_level_offset_past_the_last_record_is_explicit():
+    """走完整條工具路徑（create_list_tool → format_list_response）也要有訊息."""
+    client = _StubClient([{"Code": "2330", "Company": "台積電", "ListingDate": "1123456"}])
+    tools = register_module_tools(listing, client)
+
+    result = tools["get_recently_listed_companies"](offset=50)
+
+    assert "超出範圍" in result, f"offset 越界未給明確訊息: {result!r}"
 
 
 @pytest.mark.parametrize("rows", [[], [{"Code": "", "Name": ""}]])

--- a/tools/history/bwibbu_all.py
+++ b/tools/history/bwibbu_all.py
@@ -2,7 +2,7 @@
 
 from typing import Optional
 from fastmcp import FastMCP
-from utils import TWSEAPIClient, handle_api_errors, DEFAULT_DISPLAY_LIMIT
+from utils import TWSEAPIClient, handle_api_errors, DEFAULT_DISPLAY_LIMIT, MSG_OFFSET_OUT_OF_RANGE
 
 # rwd/zh/afterTrading/BWIBBU_d honours the `date` parameter and echoes it back.
 # The older /exchangeReport/BWIBBU_ALL silently ignores `date` entirely — every
@@ -66,7 +66,9 @@ def register_tools(mcp: FastMCP, client: Optional[TWSEAPIClient] = None) -> None
         total = len(data)
         page = data[offset:offset + limit]
         if not page:
-            return f"offset={offset} 已超出範圍，{date} 的估值資料共 {total} 筆"
+            return MSG_OFFSET_OUT_OF_RANGE.format(
+                offset=offset, data_type=f"{date} 的估值資料", count=total
+            )
 
         title = resp.get("title") or f"全市場估值資料 - {date}"
         page_note = f"，顯示第 {offset + 1}–{offset + len(page)} 筆" if total > len(page) else ""

--- a/tools/history/margin_balance.py
+++ b/tools/history/margin_balance.py
@@ -3,7 +3,7 @@
 from datetime import datetime, timedelta
 from typing import Optional
 from fastmcp import FastMCP
-from utils import TWSEAPIClient, handle_api_errors, DEFAULT_DISPLAY_LIMIT
+from utils import TWSEAPIClient, handle_api_errors, DEFAULT_DISPLAY_LIMIT, MSG_OFFSET_OUT_OF_RANGE
 
 MI_MARGN_URL = "https://www.twse.com.tw/exchangeReport/MI_MARGN"
 MAX_RETRY_DAYS = 7
@@ -69,7 +69,9 @@ def register_tools(mcp: FastMCP, client: Optional[TWSEAPIClient] = None) -> None
         total = len(data)
         page = data[offset:offset + limit]
         if not page:
-            return f"offset={offset} 已超出範圍，{actual_date} 的融資融券資料共 {total} 筆"
+            return MSG_OFFSET_OUT_OF_RANGE.format(
+                offset=offset, data_type=f"{actual_date} 的融資融券資料", count=total
+            )
 
         date_note = f"（原查詢 {date}，實際資料日 {actual_date}）" if actual_date != date else ""
         page_note = f"，顯示第 {offset + 1}–{offset + len(page)} 筆" if total > len(page) else ""

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -9,6 +9,7 @@ from .constants import (
     MSG_QUERY_FAILED,
     MSG_NO_DATA_FOR_CODE,
     MSG_NO_MATCHING_DATA,
+    MSG_OFFSET_OUT_OF_RANGE,
     MSG_TOTAL_RECORDS,
     SUMMARY_ROW_LABELS,
 )
@@ -40,6 +41,7 @@ __all__ = [
     "MSG_QUERY_FAILED",
     "MSG_NO_DATA_FOR_CODE",
     "MSG_NO_MATCHING_DATA",
+    "MSG_OFFSET_OUT_OF_RANGE",
     "MSG_TOTAL_RECORDS",
     "SUMMARY_ROW_LABELS",
     "handle_api_errors",

--- a/utils/constants.py
+++ b/utils/constants.py
@@ -12,6 +12,9 @@ MSG_NO_DATA_FOR_CODE = "查無{query_target}的{data_type}"
 # 清單經過篩選（name 關鍵字、有效欄位檢查）後一筆不剩時使用。與 MSG_NO_DATA 分開：
 # 那句是「來源整份沒有資料」，這句是「來源有資料，但沒有符合這次查詢條件的」。
 MSG_NO_MATCHING_DATA = "查無符合條件的{data_type}。"
+# offset 翻過資料尾端時使用。與上面兩句再分開：資料存在、條件也有符合的，只是這一頁
+# 已經沒有東西了。少了這句，表頭會印出「顯示第 101–2 筆」這種不可能的區間後接零列資料。
+MSG_OFFSET_OUT_OF_RANGE = "offset={offset} 已超出範圍，{data_type}共 {count} 筆。"
 
 # Success messages
 MSG_TOTAL_RECORDS = "共有 {count} 筆{data_type}："

--- a/utils/formatters.py
+++ b/utils/formatters.py
@@ -1,7 +1,12 @@
 """Data formatting utilities."""
 
 from typing import Any, List, Union, Sequence
-from .constants import MSG_TOTAL_RECORDS, MSG_NO_MATCHING_DATA, DEFAULT_DISPLAY_LIMIT
+from .constants import (
+    MSG_TOTAL_RECORDS,
+    MSG_NO_MATCHING_DATA,
+    MSG_OFFSET_OUT_OF_RANGE,
+    DEFAULT_DISPLAY_LIMIT,
+)
 from .types import TWSEDataItem, DataFormatter
 
 def format_properties_with_values_multiline(data: TWSEDataItem) -> str:
@@ -130,8 +135,9 @@ def format_list_response(
         offset: Number of records to skip from the start (default 0)
 
     Returns:
-        Formatted string with header, items, and pagination info, or MSG_NO_MATCHING_DATA
-        when there is nothing to show
+        Formatted string with header, items, and pagination info, MSG_NO_MATCHING_DATA
+        when there is nothing to show, or MSG_OFFSET_OUT_OF_RANGE when offset is past
+        the last record
     """
     if not data:
         # 呼叫端多半在抓完資料後才做 name 關鍵字或有效欄位過濾，過濾到一筆不剩時就會走到
@@ -140,6 +146,13 @@ def format_list_response(
         return MSG_NO_MATCHING_DATA.format(data_type=data_type)
 
     total = len(data)
+    if offset >= total:
+        # offset 已經翻過最後一筆。原本仍照常組表頭，輸出會變成「共有 2 筆…（顯示第
+        # 101–2 筆）」這種不可能的區間後面接零列資料，呼叫端無從分辨是自己翻過頭還是
+        # 工具壞掉。tools/history/margin_balance.py 與 bwibbu_all.py 兩支手寫分頁的工具
+        # 早就會講清楚（tests/e2e/test_output_limits.py 有斷言），這裡補上同樣的行為。
+        return MSG_OFFSET_OUT_OF_RANGE.format(offset=offset, data_type=data_type, count=total)
+
     page_data = data[offset:offset + limit]
     end = min(offset + limit, total)
 


### PR DESCRIPTION
## 改了什麼

`format_list_response` 在組表頭之前沒有先確認這一頁到底有沒有資料。`offset` 只要翻過最後一筆，輸出就會變成一個不可能的區間，後面接零列資料：

```python
>>> format_list_response([{"Code": "2330"}, {"Code": "2317"}], "測試資料", offset=100)
'共有 2 筆測試資料：（顯示第 101–2 筆）\n\n'
```

本 PR 在 `utils/formatters.py:138` 加一道 `offset >= total` 的判斷，改回傳新的訊息常數 `MSG_OFFSET_OUT_OF_RANGE`（`utils/constants.py:15`）：

```
offset=100 已超出範圍，測試資料共 2 筆。
```

順手把原本各自寫死同一句話的 `tools/history/margin_balance.py` 與 `tools/history/bwibbu_all.py` 兩處改用同一個常數。

## 為什麼

- 呼叫端無法分辨這是「自己翻頁翻過頭」還是「工具壞了」。而且 `remaining = total - offset - limit` 在這種情況是負數，連「還有 N 筆，使用 offset=… 查看更多」這個唯一能指回合法 offset 的提示也不會出現（`utils/formatters.py:166`），等於完全沒有線索可以修正查詢。
- 影響範圍不小：`create_list_tool` 產生的 37 支工具（`utils/tool_factory.py:106`）全部都開放 `limit`/`offset` 參數並經由這個函式排版，另外還有 14 個直接呼叫點，分布在 `tools/trading/market.py:254,313,352`、`tools/trading/warrants.py:48,67,86`、`tools/company/basic_info.py:190,265,322,379,413`、`tools/other.py:33,44,61`。
- 這不是新行為，是既有慣例漏掉的地方：兩支自己手寫分頁的工具早就答得很清楚——`tools/history/margin_balance.py:72` 與 `tools/history/bwibbu_all.py:69` 都會回「offset=… 已超出範圍，…共 N 筆」，且 `tests/e2e/test_output_limits.py:60,73` 有斷言。共用的排版函式反而沒有，等於同一個情境兩種答案。

## 遵循了哪些既有慣例

- **訊息字串集中在 `utils/constants.py`**：`MSG_OFFSET_OUT_OF_RANGE` 就放在 `MSG_NO_DATA` / `MSG_NO_MATCHING_DATA` 旁邊，也是 PR #78 放「過濾後一筆不剩」那句話的位置；三句話的分工在註解裡寫明（來源整份沒資料 / 沒有符合條件的 / 這一頁翻過頭了）。並經 `utils/__init__.py` 匯出，與其他 `MSG_*` 一致。
- **離線單元測試放在既有檔案**：新增的測試寫在 `tests/test_list_response_unit.py`，也就是 PR #78 為同一個函式建立的檔案，沿用其中的 `_StubClient` 與 `tests/helpers.py` 的 `register_module_tools`，不打網路。
- 中文註解、中文回覆字串、`@mcp.tool` + `@handle_api_errors` 的模組結構皆未更動。

## 驗證了什麼

- `uv sync --extra dev` 正常完成。
- 離線單元測試全數通過：`uv run pytest tests/test_list_response_unit.py tests/test_helpers_unit.py tests/test_taifex_date_range_unit.py tests/test_yearly_history_date_unit.py tests/test_news_date_range.py` → **34 passed**（其中 4 個是本次新增）。
- 新增測試涵蓋：`offset` 分別為 2 / 3 / 100 時的回覆內容、「不可能區間」的回歸斷言（輸出不得含「顯示第 101」）、`offset` 仍在範圍內時分頁輸出不變的對照組，以及走完整條工具路徑（`create_list_tool` → `format_list_response`）的 `get_recently_listed_companies(offset=50)`。

## 沒能驗證的部分

本次執行環境的 proxy 擋掉對外連線（`curl https://openapi.twse.com.tw/...` 回 `CONNECT tunnel failed, response 403`），因此 `tests/test_api_schemas.py` 與 `tests/e2e/` 這些會打真實 TWSE/TAIFEX API 的測試無法執行（`uv run pytest tests/ -k "not e2e"` 的 65 個失敗全部落在 `test_api_schemas.py`，成因是連不到上游，與本次修改無關）。特別是 `tests/e2e/test_output_limits.py` 那兩個 `超出範圍` 斷言我無法實際跑過；不過它們斷言的是 `margin_balance` / `bwibbu_all` 的回覆含有「超出範圍」四字，而這兩支改用常數後字面仍包含該詞（只多了句號），行為不變。

## 刻意排除在範圍外的部分

- 另外 29 支自己手寫分頁、沒有經過 `format_list_response` 的工具（`tools/history/`、`tools/otc/`、`tools/market/statistics.py`、`tools/trading/market.py:375` 的 `get_daily_securities_lending_volume` 等）同樣有這個問題。它們的表頭格式各不相同，一次改完會是另一個量級的 diff，留待後續處理。
- 沒有處理 `offset` 傳負數的情況（目前會從尾端往回取），也沒有動 `limit=0` 的行為——這次的判斷式刻意用精準的 `offset >= total`，不碰這兩種輸入。
- 沒有把任何手寫分頁改寫成 `format_list_response`：那會大幅改動工具對外回傳的中文字串，屬於公開介面，不在一次 bug fix 的範圍內。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UAhfdd9PhxWFsQyq23nrYq

---
_Generated by [Claude Code](https://claude.ai/code/session_01UAhfdd9PhxWFsQyq23nrYq)_