### PR TITLE
fix: 自行分頁的 16 支工具在 offset 越界時也要明說「已超出範圍」

### DIFF
--- a/tests/test_pagination_offset_unit.py
+++ b/tests/test_pagination_offset_unit.py
@@ -1,0 +1,207 @@
+"""自行分頁的工具在 offset 翻過資料尾端時的回覆（不打網路）。
+
+format_list_response 已經會在 offset 越界時回 MSG_OFFSET_OUT_OF_RANGE（見
+test_list_response_unit.py），但有 14 支工具不經過它、自己切 page_data 並自己組表頭。
+那些工具原本會輸出「共 2 筆…顯示第 1000–2 筆」這種不可能的區間後面接零列資料，
+呼叫端無從分辨是自己翻過頭還是工具壞掉。此處逐一釘住這個行為。
+"""
+
+import pytest
+
+from tests.helpers import register_module_tools
+import tools.company.basic_info as basic_info
+import tools.history.all_stocks_daily_close as all_stocks_daily_close
+import tools.history.block_trades_detail as block_trades_detail
+import tools.history.foreign_holdings_history as foreign_holdings_history
+import tools.history.institutional as institutional
+import tools.history.short_sale_lending as short_sale_lending
+import tools.market.statistics as statistics
+import tools.otc.daily_close as otc_daily_close
+import tools.otc.index as otc_index
+import tools.otc.institutional as otc_institutional
+import tools.otc.margin_balance as otc_margin_balance
+import tools.otc.odd_lot as otc_odd_lot
+import tools.otc.peratio as otc_peratio
+import tools.trading.market as market
+
+TRADING_DATE = "20250102"
+
+
+class _StubClient:
+    """只回固定 payload 的假 client，讓工具離線跑完整條路徑."""
+
+    def __init__(self, payload):
+        self._payload = payload
+
+    def fetch_json(self, url, params=None, timeout=None, headers=None):
+        return self._payload
+
+    def fetch_data(self, endpoint, timeout=None):
+        return self._payload
+
+
+def _legacy(rows):
+    """TWSE legacy JSON 端點的回傳形狀."""
+    return {"stat": "OK", "data": rows}
+
+
+# 每支工具的最小可用 payload：欄位數要足夠讓 in-range 的那一頁也能正常排版。
+DAILY_CLOSE_ROW = ["2330", "台積電"] + ["1"] * 14                      # 16 欄，tuple 解包
+SHORT_SALE_BALANCE_ROW = ["2330", "台積電"] + ["0"] * 13                # 融券 6 + 借券 6 + 備註
+SHORT_SALE_TRADES_ROW = ["2330   台積電", "0", "0", "0", "0"]
+BLOCK_TRADE_ROW = ["2330", "台積電", "鉅額中盤", "1000", "10", "10000"]  # 6 欄，tuple 解包
+FOREIGN_HOLDINGS_ROW = ["2330", "台積電", "TW0002330008", "100", "10", "90", "10.00", "90.00"]
+T86_ROW = ["2330", "台積電"] + ["0"] * 16 + ["1,000"]                   # row[18] 非 0 才算有法人進出
+
+CASES = [
+    (
+        all_stocks_daily_close,
+        "get_all_stocks_daily_close",
+        {"date": TRADING_DATE},
+        {"stat": "OK", "tables": [{"title": f"{TRADING_DATE} 每日收盤行情", "data": [DAILY_CLOSE_ROW]}]},
+    ),
+    (
+        short_sale_lending,
+        "get_short_sale_lending_balance_history",
+        {"date": TRADING_DATE},
+        _legacy([SHORT_SALE_BALANCE_ROW]),
+    ),
+    (
+        short_sale_lending,
+        "get_short_sale_lending_trades_history",
+        {"date": TRADING_DATE},
+        _legacy([SHORT_SALE_TRADES_ROW]),
+    ),
+    (
+        block_trades_detail,
+        "get_block_trades_detail",
+        {"date": TRADING_DATE},
+        _legacy([BLOCK_TRADE_ROW]),
+    ),
+    (
+        foreign_holdings_history,
+        "get_foreign_holdings_history",
+        {"date": TRADING_DATE},
+        _legacy([FOREIGN_HOLDINGS_ROW]),
+    ),
+    (
+        institutional,
+        "get_twse_institutional_investors_summary",
+        {"date": TRADING_DATE},
+        _legacy([T86_ROW]),
+    ),
+    (
+        statistics,
+        "get_margin_trading_info",
+        {},
+        [{"Item": "融資", "TodayBalance": "100"}],
+    ),
+    (
+        basic_info,
+        "get_companies_with_independent_directors",
+        {},
+        [{"公司代號": "2330", "公司名稱": "台積電"}],
+    ),
+    (
+        market,
+        "get_top_20_volume_stocks",
+        {},
+        [{"Rank": "1", "Code": "2330", "Name": "台積電", "Date": TRADING_DATE}],
+    ),
+    (
+        market,
+        "get_daily_securities_lending_volume",
+        {},
+        [
+            {"TWSECode": "2330", "TWSEAvailableVolume": "100"},
+            {"GRETAICode": "6488", "GRETAIAvailableVolume": "100"},
+        ],
+    ),
+    (
+        otc_daily_close,
+        "get_otc_daily",
+        {},
+        [{"SecuritiesCompanyCode": "6488", "CompanyName": "環球晶"}],
+    ),
+    (
+        otc_margin_balance,
+        "get_otc_margin_balance",
+        {},
+        [{"SecuritiesCompanyCode": "6488", "CompanyName": "環球晶"}],
+    ),
+    (
+        otc_odd_lot,
+        "get_otc_odd_lot",
+        {},
+        [{"SecuritiesCompanyCode": "6488", "CompanyName": "環球晶"}],
+    ),
+    (
+        otc_peratio,
+        "get_otc_valuation",
+        {},
+        [{"SecuritiesCompanyCode": "6488", "CompanyName": "環球晶"}],
+    ),
+    (
+        otc_institutional,
+        "get_otc_institutional",
+        {},
+        [{"SecuritiesCompanyCode": "6488", "CompanyName": "環球晶"}],
+    ),
+    (
+        otc_index,
+        "get_otc_index",
+        {},
+        [{"Date": TRADING_DATE, "Close": "250"}],
+    ),
+]
+
+CASE_IDS = [f"{module.__name__}::{tool_name}" for module, tool_name, _kwargs, _payload in CASES]
+
+
+@pytest.mark.parametrize("module,tool_name,kwargs,payload", CASES, ids=CASE_IDS)
+def test_offset_past_the_last_record_is_explicit(module, tool_name, kwargs, payload):
+    """offset 翻過尾端時要講清楚，不能只回一個空頁的表頭."""
+    tools = register_module_tools(module, _StubClient(payload))
+
+    result = tools[tool_name](offset=999, **kwargs)
+
+    assert "超出範圍" in result, f"offset 越界未給明確訊息: {result!r}"
+    assert "顯示第 1000" not in result, f"仍印出不可能的分頁區間: {result!r}"
+
+
+@pytest.mark.parametrize("module,tool_name,kwargs,payload", CASES, ids=CASE_IDS)
+def test_first_page_is_unchanged(module, tool_name, kwargs, payload):
+    """對照組：offset 還在範圍內時輸出不受影響（確認上面的守衛不會誤判）."""
+    tools = register_module_tools(module, _StubClient(payload))
+
+    result = tools[tool_name](**kwargs)
+
+    assert "超出範圍" not in result, f"offset=0 被誤判為越界: {result!r}"
+    assert "查詢失敗" not in result, f"工具拋出例外: {result!r}"
+    assert "共" in result, f"未輸出總筆數表頭: {result!r}"
+
+
+def test_securities_lending_prints_only_the_market_that_still_has_rows():
+    """兩市場共用 offset：只有一邊翻過尾端時，該區塊要整段不印，而非印出空區塊."""
+    payload = [
+        {"TWSECode": "2330", "TWSEAvailableVolume": "100"},
+        {"TWSECode": "2317", "TWSEAvailableVolume": "200"},
+        {"GRETAICode": "6488", "GRETAIAvailableVolume": "300"},
+    ]
+    tools = register_module_tools(market, _StubClient(payload))
+
+    result = tools["get_daily_securities_lending_volume"](limit=1, offset=1)
+
+    assert "【上市股票】" in result, "上市還有第 2 筆，卻沒印出來"
+    assert "【上櫃股票】" not in result, "上櫃只有 1 筆，offset=1 已越界卻仍印出區塊"
+
+
+def test_no_match_after_name_filter_is_explicit():
+    """name 關鍵字過濾到一筆不剩時要有訊息，不能回「共有 0 筆」的空表頭."""
+    payload = [{"Rank": "1", "Code": "2330", "Name": "台積電", "Date": TRADING_DATE}]
+    tools = register_module_tools(market, _StubClient(payload))
+
+    result = tools["get_top_20_volume_stocks"](name="不存在的公司")
+
+    assert "查無" in result, f"未說明查無符合條件的資料: {result!r}"
+    assert "共有 0 筆" not in result, f"仍輸出 0 筆的空表頭: {result!r}"

--- a/tools/company/basic_info.py
+++ b/tools/company/basic_info.py
@@ -8,6 +8,8 @@ from utils import (
     has_meaningful_data,
     format_meaningful_fields_only,
     MSG_NO_DATA,
+    MSG_NO_MATCHING_DATA,
+    MSG_OFFSET_OUT_OF_RANGE,
     DEFAULT_DISPLAY_LIMIT,
     format_list_response,
     create_company_tool,
@@ -213,9 +215,15 @@ def register_tools(mcp: FastMCP, client: Optional[TWSEAPIClient] = None) -> None
         sorted_companies = sorted(companies.items())
         if name:
             sorted_companies = [(c, n) for c, n in sorted_companies if name in n]
+            if not sorted_companies:
+                return MSG_NO_MATCHING_DATA.format(data_type="上市公司獨立董監事兼任情形")
 
         total = len(sorted_companies)
         page_data = sorted_companies[offset:offset + limit]
+        if not page_data:
+            return MSG_OFFSET_OUT_OF_RANGE.format(
+                offset=offset, data_type="具有獨立董監事資料的上市公司", count=total
+            )
         end = min(offset + limit, total)
 
         header = f"共有 {total} 家公司具有獨立董監事資料"

--- a/tools/history/all_stocks_daily_close.py
+++ b/tools/history/all_stocks_daily_close.py
@@ -2,7 +2,7 @@
 
 from typing import Optional
 from fastmcp import FastMCP
-from utils import TWSEAPIClient, handle_api_errors, DEFAULT_DISPLAY_LIMIT
+from utils import TWSEAPIClient, handle_api_errors, DEFAULT_DISPLAY_LIMIT, MSG_OFFSET_OUT_OF_RANGE
 
 MI_INDEX_URL = "https://www.twse.com.tw/rwd/zh/afterTrading/MI_INDEX"
 
@@ -63,6 +63,10 @@ def register_tools(mcp: FastMCP, client: Optional[TWSEAPIClient] = None) -> None
 
         total = len(data)
         page_data = data[offset:offset + limit]
+        if not page_data:
+            return MSG_OFFSET_OUT_OF_RANGE.format(
+                offset=offset, data_type=f"{date} 的收盤行情資料", count=total
+            )
         end = min(offset + limit, total)
 
         header = f"【{date} 全市場每日收盤行情】（共 {total} 筆"

--- a/tools/history/block_trades_detail.py
+++ b/tools/history/block_trades_detail.py
@@ -2,7 +2,13 @@
 
 from typing import Optional
 from fastmcp import FastMCP
-from utils import TWSEAPIClient, handle_api_errors, DEFAULT_DISPLAY_LIMIT, SUMMARY_ROW_LABELS
+from utils import (
+    TWSEAPIClient,
+    handle_api_errors,
+    DEFAULT_DISPLAY_LIMIT,
+    SUMMARY_ROW_LABELS,
+    MSG_OFFSET_OUT_OF_RANGE,
+)
 
 BFIAUU_URL = "https://www.twse.com.tw/rwd/zh/block/BFIAUU"
 
@@ -56,6 +62,10 @@ def register_tools(mcp: FastMCP, client: Optional[TWSEAPIClient] = None) -> None
 
         total = len(data)
         page_data = data[offset:offset + limit]
+        if not page_data:
+            return MSG_OFFSET_OUT_OF_RANGE.format(
+                offset=offset, data_type=f"{date} 的鉅額交易資料", count=total
+            )
         end = min(offset + limit, total)
 
         title = resp.get("title", f"{date} 鉅額交易日成交資訊")

--- a/tools/history/foreign_holdings_history.py
+++ b/tools/history/foreign_holdings_history.py
@@ -2,7 +2,7 @@
 
 from typing import Optional
 from fastmcp import FastMCP
-from utils import TWSEAPIClient, handle_api_errors, DEFAULT_DISPLAY_LIMIT
+from utils import TWSEAPIClient, handle_api_errors, DEFAULT_DISPLAY_LIMIT, MSG_OFFSET_OUT_OF_RANGE
 
 MI_QFIIS_URL = "https://www.twse.com.tw/rwd/zh/fund/MI_QFIIS"
 
@@ -53,6 +53,10 @@ def register_tools(mcp: FastMCP, client: Optional[TWSEAPIClient] = None) -> None
 
         total = len(data)
         page_data = data[offset:offset + limit]
+        if not page_data:
+            return MSG_OFFSET_OUT_OF_RANGE.format(
+                offset=offset, data_type=f"{date} 的外資及陸資持股資料", count=total
+            )
         end = min(offset + limit, total)
 
         title = resp.get("title", f"{date} 外資及陸資投資持股統計")

--- a/tools/history/institutional.py
+++ b/tools/history/institutional.py
@@ -2,7 +2,7 @@
 
 from typing import Optional
 from fastmcp import FastMCP
-from utils import TWSEAPIClient, handle_api_errors, DEFAULT_DISPLAY_LIMIT
+from utils import TWSEAPIClient, handle_api_errors, DEFAULT_DISPLAY_LIMIT, MSG_OFFSET_OUT_OF_RANGE
 
 T86_URL = "https://www.twse.com.tw/rwd/zh/fund/T86"
 
@@ -76,12 +76,18 @@ def register_tools(mcp: FastMCP, client: Optional[TWSEAPIClient] = None) -> None
         # Filter rows where any institutional investor has non-zero net
         # Some rows (e.g. bond ETFs) have fewer than 19 columns — skip them
         active = [row for row in data if len(row) > IDX_TOTAL_NET and _parse_num(row[IDX_TOTAL_NET]) != 0]
+        if not active:
+            return f"查無 {date} 有法人進出的個股資料"
 
         # Sort by absolute value of total net descending
         active.sort(key=lambda r: abs(_parse_num(r[IDX_TOTAL_NET])), reverse=True)
 
         total = len(active)
         page_data = active[offset:offset + limit]
+        if not page_data:
+            return MSG_OFFSET_OUT_OF_RANGE.format(
+                offset=offset, data_type=f"{date} 有法人進出的個股", count=total
+            )
         end = min(offset + limit, total)
 
         header = f"【{title}】（共 {total} 支有法人進出"

--- a/tools/history/short_sale_lending.py
+++ b/tools/history/short_sale_lending.py
@@ -6,7 +6,13 @@ cover the securities-lending (借券) side of short selling.
 
 from typing import Optional
 from fastmcp import FastMCP
-from utils import TWSEAPIClient, handle_api_errors, DEFAULT_DISPLAY_LIMIT, SUMMARY_ROW_LABELS
+from utils import (
+    TWSEAPIClient,
+    handle_api_errors,
+    DEFAULT_DISPLAY_LIMIT,
+    SUMMARY_ROW_LABELS,
+    MSG_OFFSET_OUT_OF_RANGE,
+)
 
 TWT93U_URL = "https://www.twse.com.tw/rwd/zh/marginTrading/TWT93U"
 TWTASU_URL = "https://www.twse.com.tw/rwd/zh/afterTrading/TWTASU"
@@ -59,6 +65,10 @@ def register_tools(mcp: FastMCP, client: Optional[TWSEAPIClient] = None) -> None
 
         total = len(data)
         page_data = data[offset:offset + limit]
+        if not page_data:
+            return MSG_OFFSET_OUT_OF_RANGE.format(
+                offset=offset, data_type=f"{date} 的信用額度總量管制餘額資料", count=total
+            )
         end = min(offset + limit, total)
 
         title = resp.get("title", f"{date} 信用額度總量管制餘額表")
@@ -137,6 +147,10 @@ def register_tools(mcp: FastMCP, client: Optional[TWSEAPIClient] = None) -> None
 
         total = len(parsed)
         page_data = parsed[offset:offset + limit]
+        if not page_data:
+            return MSG_OFFSET_OUT_OF_RANGE.format(
+                offset=offset, data_type=f"{date} 的融券借券賣出成交量值資料", count=total
+            )
         end = min(offset + limit, total)
 
         title = resp.get("title", f"{date} 當日融券賣出與借券賣出成交量值")

--- a/tools/market/statistics.py
+++ b/tools/market/statistics.py
@@ -2,7 +2,14 @@
 
 from typing import Optional
 from fastmcp import FastMCP
-from utils import TWSEAPIClient, MSG_NO_DATA, DEFAULT_DISPLAY_LIMIT, handle_api_errors, format_multiple_records
+from utils import (
+    TWSEAPIClient,
+    MSG_NO_DATA,
+    MSG_OFFSET_OUT_OF_RANGE,
+    DEFAULT_DISPLAY_LIMIT,
+    handle_api_errors,
+    format_multiple_records,
+)
 
 def register_tools(mcp: FastMCP, client: Optional[TWSEAPIClient] = None) -> None:
     """Register market statistics tools with the MCP instance."""
@@ -24,6 +31,10 @@ def register_tools(mcp: FastMCP, client: Optional[TWSEAPIClient] = None) -> None
 
         total = len(data)
         page_data = data[offset:offset + limit]
+        if not page_data:
+            return MSG_OFFSET_OUT_OF_RANGE.format(
+                offset=offset, data_type="集中市場融資融券餘額資料", count=total
+            )
         end = min(offset + limit, total)
 
         result = f"共有 {total} 筆集中市場融資融券餘額資料"

--- a/tools/otc/daily_close.py
+++ b/tools/otc/daily_close.py
@@ -2,7 +2,7 @@
 
 from typing import Optional
 from fastmcp import FastMCP
-from utils import TWSEAPIClient, handle_api_errors, DEFAULT_DISPLAY_LIMIT
+from utils import TWSEAPIClient, handle_api_errors, DEFAULT_DISPLAY_LIMIT, MSG_OFFSET_OUT_OF_RANGE
 
 TPEX_DAILY_CLOSE_URL = "https://www.tpex.org.tw/openapi/v1/tpex_mainboard_daily_close_quotes"
 
@@ -37,6 +37,10 @@ def register_tools(mcp: FastMCP, client: Optional[TWSEAPIClient] = None) -> None
 
         total = len(data)
         page_data = data[offset:offset + limit]
+        if not page_data:
+            return MSG_OFFSET_OUT_OF_RANGE.format(
+                offset=offset, data_type="上櫃市場收盤行情資料", count=total
+            )
         end = min(offset + limit, total)
 
         header = f"【上櫃市場收盤行情】（共 {total} 筆"

--- a/tools/otc/index.py
+++ b/tools/otc/index.py
@@ -2,7 +2,7 @@
 
 from typing import Optional
 from fastmcp import FastMCP
-from utils import TWSEAPIClient, handle_api_errors, DEFAULT_DISPLAY_LIMIT
+from utils import TWSEAPIClient, handle_api_errors, DEFAULT_DISPLAY_LIMIT, MSG_OFFSET_OUT_OF_RANGE
 
 TPEX_INDEX_URL = "https://www.tpex.org.tw/openapi/v1/tpex_index"
 
@@ -30,6 +30,10 @@ def register_tools(mcp: FastMCP, client: Optional[TWSEAPIClient] = None) -> None
 
         total = len(data)
         page_data = data[offset:offset + limit]
+        if not page_data:
+            return MSG_OFFSET_OUT_OF_RANGE.format(
+                offset=offset, data_type="櫃買指數資料", count=total
+            )
         end = min(offset + limit, total)
 
         header = f"【櫃買市場指數】（共 {total} 筆"

--- a/tools/otc/institutional.py
+++ b/tools/otc/institutional.py
@@ -2,7 +2,7 @@
 
 from typing import Optional
 from fastmcp import FastMCP
-from utils import TWSEAPIClient, handle_api_errors, DEFAULT_DISPLAY_LIMIT
+from utils import TWSEAPIClient, handle_api_errors, DEFAULT_DISPLAY_LIMIT, MSG_OFFSET_OUT_OF_RANGE
 
 TPEX_3INSTI_URL = "https://www.tpex.org.tw/openapi/v1/tpex_3insti_daily_trading"
 
@@ -43,6 +43,10 @@ def register_tools(mcp: FastMCP, client: Optional[TWSEAPIClient] = None) -> None
 
         total = len(data)
         page_data = data[offset:offset + limit]
+        if not page_data:
+            return MSG_OFFSET_OUT_OF_RANGE.format(
+                offset=offset, data_type="上櫃市場三大法人買賣超資料", count=total
+            )
         end = min(offset + limit, total)
 
         header = f"【上櫃三大法人買賣超】（共 {total} 筆"

--- a/tools/otc/margin_balance.py
+++ b/tools/otc/margin_balance.py
@@ -2,7 +2,7 @@
 
 from typing import Optional
 from fastmcp import FastMCP
-from utils import TWSEAPIClient, handle_api_errors, DEFAULT_DISPLAY_LIMIT
+from utils import TWSEAPIClient, handle_api_errors, DEFAULT_DISPLAY_LIMIT, MSG_OFFSET_OUT_OF_RANGE
 
 TPEX_MARGIN_URL = "https://www.tpex.org.tw/openapi/v1/tpex_mainboard_margin_balance"
 
@@ -37,6 +37,10 @@ def register_tools(mcp: FastMCP, client: Optional[TWSEAPIClient] = None) -> None
 
         total = len(data)
         page_data = data[offset:offset + limit]
+        if not page_data:
+            return MSG_OFFSET_OUT_OF_RANGE.format(
+                offset=offset, data_type="上櫃融資融券餘額資料", count=total
+            )
         end = min(offset + limit, total)
 
         header = f"【上櫃融資融券餘額】（共 {total} 筆"

--- a/tools/otc/odd_lot.py
+++ b/tools/otc/odd_lot.py
@@ -2,7 +2,7 @@
 
 from typing import Optional
 from fastmcp import FastMCP
-from utils import TWSEAPIClient, handle_api_errors, DEFAULT_DISPLAY_LIMIT
+from utils import TWSEAPIClient, handle_api_errors, DEFAULT_DISPLAY_LIMIT, MSG_OFFSET_OUT_OF_RANGE
 
 TPEX_ODD_LOT_URL = "https://www.tpex.org.tw/openapi/v1/tpex_odd_stock"
 
@@ -37,6 +37,10 @@ def register_tools(mcp: FastMCP, client: Optional[TWSEAPIClient] = None) -> None
 
         total = len(data)
         page_data = data[offset:offset + limit]
+        if not page_data:
+            return MSG_OFFSET_OUT_OF_RANGE.format(
+                offset=offset, data_type="上櫃零股交易資料", count=total
+            )
         end = min(offset + limit, total)
 
         header = f"【上櫃零股交易行情】（共 {total} 筆"

--- a/tools/otc/peratio.py
+++ b/tools/otc/peratio.py
@@ -2,7 +2,7 @@
 
 from typing import Optional
 from fastmcp import FastMCP
-from utils import TWSEAPIClient, handle_api_errors, DEFAULT_DISPLAY_LIMIT
+from utils import TWSEAPIClient, handle_api_errors, DEFAULT_DISPLAY_LIMIT, MSG_OFFSET_OUT_OF_RANGE
 
 TPEX_PE_URL = "https://www.tpex.org.tw/openapi/v1/tpex_mainboard_peratio_analysis"
 
@@ -36,6 +36,10 @@ def register_tools(mcp: FastMCP, client: Optional[TWSEAPIClient] = None) -> None
 
         total = len(data)
         page_data = data[offset:offset + limit]
+        if not page_data:
+            return MSG_OFFSET_OUT_OF_RANGE.format(
+                offset=offset, data_type="上櫃市場估值資料", count=total
+            )
         end = min(offset + limit, total)
 
         header = f"【上櫃市場估值資料】（共 {total} 筆"

--- a/tools/trading/market.py
+++ b/tools/trading/market.py
@@ -5,6 +5,8 @@ from fastmcp import FastMCP
 from utils import (
     TWSEAPIClient,
     MSG_NO_DATA,
+    MSG_NO_MATCHING_DATA,
+    MSG_OFFSET_OUT_OF_RANGE,
     handle_api_errors,
     format_list_response,
     create_list_tool,
@@ -164,6 +166,8 @@ def register_tools(mcp: FastMCP, client: Optional[TWSEAPIClient] = None) -> None
 
         if name:
             data = [d for d in data if name in d.get("Name", "")]
+            if not data:
+                return MSG_NO_MATCHING_DATA.format(data_type="集中市場每日成交量前二十名證券")
 
         date = data[0].get("Date", "N/A") if data else "N/A"
 
@@ -185,6 +189,10 @@ def register_tools(mcp: FastMCP, client: Optional[TWSEAPIClient] = None) -> None
 
         total = len(data)
         page_data = data[offset:offset + limit]
+        if not page_data:
+            return MSG_OFFSET_OUT_OF_RANGE.format(
+                offset=offset, data_type="集中市場每日成交量前二十名證券資料", count=total
+            )
         end = min(offset + limit, total)
 
         header = f"集中市場每日成交量前二十名證券 (日期: {date})（共 {total} 筆"
@@ -369,10 +377,18 @@ def register_tools(mcp: FastMCP, client: Optional[TWSEAPIClient] = None) -> None
 
         total_twse = len(twse_data)
         total_gretai = len(gretai_data)
+        # 兩個市場共用同一個 offset，所以要先切好頁再決定要印哪些區塊：只有「兩邊都翻過尾端」
+        # 才是真的越界；只有一邊沒資料時，該區塊整段不印即可。
+        page_twse = twse_data[offset:offset + limit]
+        page_gretai = gretai_data[offset:offset + limit]
+        if not page_twse and not page_gretai:
+            return MSG_OFFSET_OUT_OF_RANGE.format(
+                offset=offset, data_type="上市上櫃股票當日可借券賣出股數資料", count=len(data)
+            )
+
         result = f"共有 {len(data)} 筆上市上櫃股票當日可借券賣出股數資料：\n\n"
 
-        if twse_data:
-            page_twse = twse_data[offset:offset + limit]
+        if page_twse:
             result += f"【上市股票】（共 {total_twse} 筆，顯示第 {offset + 1}–{min(offset + limit, total_twse)} 筆）\n"
             for item in page_twse:
                 stock_code = item.get("TWSECode", "N/A")
@@ -382,8 +398,7 @@ def register_tools(mcp: FastMCP, client: Optional[TWSEAPIClient] = None) -> None
             if remaining_twse > 0:
                 result += f"... 還有 {remaining_twse} 筆，使用 offset={offset + limit} 查看更多\n"
 
-        if gretai_data:
-            page_gretai = gretai_data[offset:offset + limit]
+        if page_gretai:
             result += f"\n【上櫃股票】（共 {total_gretai} 筆，顯示第 {offset + 1}–{min(offset + limit, total_gretai)} 筆）\n"
             for item in page_gretai:
                 stock_code = item.get("GRETAICode", "N/A")


### PR DESCRIPTION
## 改了什麼

把 PR #80 的 offset 越界訊息，補到**沒有走 `format_list_response`、自己切頁自己組表頭**的 16 支工具上（14 個模組）：

| 模組 | 工具 |
|------|------|
| `tools/history/all_stocks_daily_close.py` | `get_all_stocks_daily_close` |
| `tools/history/short_sale_lending.py` | `get_short_sale_lending_balance_history`、`get_short_sale_lending_trades_history` |
| `tools/history/block_trades_detail.py` | `get_block_trades_detail` |
| `tools/history/foreign_holdings_history.py` | `get_foreign_holdings_history` |
| `tools/history/institutional.py` | `get_twse_institutional_investors_summary` |
| `tools/trading/market.py` | `get_top_20_volume_stocks`、`get_daily_securities_lending_volume` |
| `tools/company/basic_info.py` | `get_companies_with_independent_directors` |
| `tools/market/statistics.py` | `get_margin_trading_info` |
| `tools/otc/{daily_close,margin_balance,odd_lot,peratio,institutional,index}.py` | 6 支上櫃清單工具 |

作法與已修好的兩支完全一致：切完 `page_data` 後、組表頭之前檢查該頁是否為空，空的就回 `MSG_OFFSET_OUT_OF_RANGE`。範圍內的分頁輸出一字未動。

另外三處是這次守衛的前置條件，一併修掉（否則 offset=0 但過濾後一筆不剩時會被誤報成「越界」）：

- `get_top_20_volume_stocks` 的 name 關鍵字過濾（`tools/trading/market.py:167`）
- `get_companies_with_independent_directors` 的 name 關鍵字過濾（`tools/company/basic_info.py:217`）
- `get_twse_institutional_investors_summary` 的「買賣超為 0 全部濾掉」（`tools/history/institutional.py:78`）

三者原本會輸出「共 0 筆」的空表頭，現在改回 `查無…`，與同模組其他過濾條件的既有行為一致。

`get_daily_securities_lending_volume` 是特例：上市、上櫃兩個清單共用同一個 `offset`，所以只有「兩邊都翻過尾端」才回越界訊息；只有一邊沒資料時，該區塊整段不印，而不是印出一個空區塊。

## 為什麼是改善

PR #80（`utils/formatters.py:149`）只涵蓋 `format_list_response`，以及改用該訊息的 `tools/history/margin_balance.py:71`、`tools/history/bwibbu_all.py:68`。上面這 16 支工具都有 `limit` / `offset` 參數，但完全不經過那個 formatter，所以同一個缺陷還在：

```
get_otc_index(offset=999)
'【櫃買市場指數】（共 60 筆，顯示第 1000–60 筆）\n'
```

呼叫端看到的是「一個不可能的區間 + 零列資料」，無法分辨是自己翻過頭、當天真的沒資料、還是工具壞了；而且 `remaining = total - offset - limit` 是負數，連「還有 N 筆，使用 offset=… 查看更多」的提示也不會出現，沒有任何線索指回合法的 offset。這 16 支裡包含整個上櫃清單工具群（`tools/otc/*`）與全市場收盤行情、鉅額交易、外資持股、三大法人日報等常用查詢。

## 遵循了哪項既有慣例

- 訊息單一來源：沿用 `utils/constants.py:17` 的 `MSG_OFFSET_OUT_OF_RANGE`，不新增字串、不改任何工具現有的中文輸出。
- 守衛寫法：照抄 `tools/history/margin_balance.py:71` 與 `tools/history/bwibbu_all.py:68` 的形狀（`page = data[offset:offset+limit]` 後緊接 `if not page: return MSG_OFFSET_OUT_OF_RANGE.format(...)`），沒有引入新的抽象或 helper。
- 過濾無結果就明說：`tools/history/all_stocks_daily_close.py:57`、`tools/history/block_trades_detail.py:52` 等模組的 `stock_no` / `name` 過濾早就這樣做，上述三處只是補齊漏掉的分支。
- 離線單元測試：`tests/test_pagination_offset_unit.py` 比照 `tests/test_list_response_unit.py`，用 `tests/helpers.py:96` 的 `register_module_tools` 搭配 stub client 走完整條工具路徑，不打網路。

## 怎麼驗證的

新增測試 34 項（16 支工具 × 越界 + 同範圍內對照，另加雙市場區塊與 name 過濾各 1）：

```
$ uv sync --extra dev
$ PYTEST_DELAY_SECONDS=0 uv run pytest tests/test_pagination_offset_unit.py -q
34 passed in 0.08s
```

把 `tools/` 的修改暫時 stash 起來重跑，確認測試真的咬得住這個缺陷：

```
$ git stash push -- tools/ && PYTEST_DELAY_SECONDS=0 uv run pytest tests/test_pagination_offset_unit.py -q
18 failed, 16 passed
```

全部離線測試：

```
$ PYTEST_DELAY_SECONDS=0 uv run pytest tests/ --ignore=tests/e2e --ignore=tests/test_api_schemas.py -q
1 failed, 83 passed
```

另外以 `python -c "import server"` 確認 159 支工具仍能全部註冊成功。

**無法驗證的部分**：本次執行環境的對外連線政策封鎖了 `openapi.twse.com.tw`（CONNECT 被 egress proxy 擋掉，回 `403 Forbidden`），所以所有會打真實 API 的測試都跑不起來——`tests/e2e/**`、`tests/test_api_schemas.py`（65 項全數因 ProxyError 失敗），以及上面那唯一 1 項失敗 `tests/test_api_client_errors.py::test_missing_company_still_reads_as_missing`（錯誤訊息即為 `查詢失敗: … Tunnel connection failed: 403 Forbidden`）。這些與本次修改無關，是環境限制；請以 CI 的每日 E2E 排程結果為準。

## 刻意排除在外的範疇

- **不把這 16 段分頁邏輯收斂成共用 helper**：各工具的表頭中文字串（`【…】（共 N 筆…）` vs `共有 N 筆…：`）是對外契約，統一格式會改動使用者看到的輸出；此 PR 只補行為缺陷，不動排版。
- **不改 `limit` / `offset` 的預設值與語意**，也不動任何工具的 docstring（即 MCP tool description）。
- **CLAUDE.md 的「Tests are E2E — they call real TWSE APIs (no mocking)」已與現況不符**（`tests/` 下已有多支 stub client 的離線單元測試）。那是既有的文件落差，留給獨立的 docs PR 處理，不混進這次的修改。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017wsUD1ReCA1MqiZ3vE7rNK

---
_Generated by [Claude Code](https://claude.ai/code/session_017wsUD1ReCA1MqiZ3vE7rNK)_